### PR TITLE
Enable exports for default imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,19 @@
     ".": {
       "browser": {
         "types": "./types/index.d.ts",
-        "import": "./src/index.js"
+        "import": "./src/index.js",
+        "default": "./src/index.js"
       },
       "default": {
         "types": "./types/node.d.ts",
-        "import": "./src/node.js"
+        "import": "./src/node.js",
+        "default": "./src/node.js"
       }
     },
     "./src/*.js": {
       "types": "./types/*.d.ts",
-      "import": "./src/*.js"
+      "import": "./src/*.js",
+      "default": "./src/*.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Hi,

I'm building a data analytics app using Hyparquet and NestJS, but couldn't import this module using the following import:

```
import { ColumnSource, parquetWriteFile } from 'hyparquet-writer';
```

These changes allow named imports following this syntax.