### PR TITLE
Default-only exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,18 +30,15 @@
     ".": {
       "browser": {
         "types": "./types/index.d.ts",
-        "import": "./src/index.js",
         "default": "./src/index.js"
       },
       "default": {
         "types": "./types/node.d.ts",
-        "import": "./src/node.js",
         "default": "./src/node.js"
       }
     },
     "./src/*.js": {
       "types": "./types/*.d.ts",
-      "import": "./src/*.js",
       "default": "./src/*.js"
     }
   },
@@ -55,15 +52,15 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "hyparquet": "1.17.1"
+    "hyparquet": "1.20.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "7.28.0",
-    "@types/node": "24.1.0",
+    "@babel/eslint-parser": "7.28.4",
+    "@types/node": "24.8.1",
     "@vitest/coverage-v8": "3.2.4",
-    "eslint": "9.32.0",
-    "eslint-plugin-jsdoc": "52.0.0",
-    "typescript": "5.8.3",
+    "eslint": "9.38.0",
+    "eslint-plugin-jsdoc": "61.1.4",
+    "typescript": "5.9.3",
     "vitest": "3.2.4"
   }
 }

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -31,9 +31,9 @@ describe('package.json', () => {
     expect(Object.keys(exports)).toEqual(['.', './src/*.js'])
     // node vs default (browser)
     expect(Object.keys(exports['.'])).toEqual(['browser', 'default'])
-    expect(Object.keys(exports['.'].browser)).toEqual(['types', 'import', 'default'])
-    expect(Object.keys(exports['.'].default)).toEqual(['types', 'import', 'default'])
+    expect(Object.keys(exports['.'].browser)).toEqual(['types', 'default'])
+    expect(Object.keys(exports['.'].default)).toEqual(['types', 'default'])
     // deep imports
-    expect(Object.keys(exports['./src/*.js'])).toEqual(['types', 'import', 'default'])
+    expect(Object.keys(exports['./src/*.js'])).toEqual(['types', 'default'])
   })
 })


### PR DESCRIPTION
`import` and `default` point to the same file, so the import branch should be unnecessary. Tested locally but I guess we'll see 🤷 