### PR TITLE
Fix RLE encoding length

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.28.5",
     "@types/node": "24.10.1",
-    "@vitest/coverage-v8": "4.0.14",
+    "@vitest/coverage-v8": "4.0.15",
     "eslint": "9.39.1",
     "eslint-plugin-jsdoc": "61.4.1",
     "typescript": "5.9.3",
-    "vitest": "4.0.14"
+    "vitest": "4.0.15"
   }
 }

--- a/src/datapage.js
+++ b/src/datapage.js
@@ -39,8 +39,10 @@ export function writeDataPageV2(writer, values, column, encoding, listValues) {
     writePlain(page, nonnull, type, type_length)
   } else if (encoding === 'RLE') {
     if (type !== 'BOOLEAN') throw new Error('RLE encoding only supported for BOOLEAN type')
-    page.appendUint32(nonnull.length) // prepend length
-    writeRleBitPackedHybrid(page, nonnull, 1)
+    const rleData = new ByteWriter()
+    writeRleBitPackedHybrid(rleData, nonnull, 1)
+    page.appendUint32(rleData.offset) // prepend byte length
+    page.appendBuffer(rleData.getBuffer())
   } else if (encoding === 'PLAIN_DICTIONARY' || encoding === 'RLE_DICTIONARY') {
     // find max bitwidth
     let maxValue = 0

--- a/src/parquet-writer.js
+++ b/src/parquet-writer.js
@@ -37,7 +37,7 @@ export function ParquetWriter({ writer, schema, compressed = true, statistics = 
  * @param {ColumnSource[]} options.columnData
  * @param {number | number[]} [options.rowGroupSize]
  */
-ParquetWriter.prototype.write = function({ columnData, rowGroupSize = 100000 }) {
+ParquetWriter.prototype.write = function({ columnData, rowGroupSize = 10000 }) {
   const columnDataRows = columnData[0]?.data?.length || 0
   for (const { groupStartIndex, groupSize } of groupIterator({ columnDataRows, rowGroupSize })) {
     const groupStartOffset = this.writer.offset


### PR DESCRIPTION
Fix #17 RLE encoding of boolean values

Hyparquet-writer was incorrectly prepending the number of values, but per the [spec](https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3) should have been prepending the byte length of the data. This PR fixes the prepended value to be byte length.

Thanks @mRamiroGonzalez for finding the issue and making very clear repro steps! :clap: 