### PR TITLE
Custom compressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,15 @@ Options can be passed to `parquetWrite` to adjust parquet file writing behavior:
 
  - `writer`: a generic writer object
  - `schema`: parquet schema object (optional)
- - `compressed`: use snappy compression (default true)
+ - `codec`: use snappy compression (default true)
+ - `compressors`: custom compressors
  - `statistics`: write column statistics (default true)
  - `rowGroupSize`: number of rows in each row group (default 100000)
  - `kvMetadata`: extra key-value metadata to be stored in the parquet footer
 
 ```javascript
 import { ByteWriter, parquetWrite } from 'hyparquet-writer'
+import { snappyCompress } from 'hysnappy'
 
 const writer = new ByteWriter()
 parquetWrite({
@@ -97,7 +99,7 @@ parquetWrite({
     { name: 'age', type: 'FIXED_LEN_BYTE_ARRAY', type_length: 4, converted_type: 'DECIMAL', scale: 2, precision: 4 },
     { name: 'dob', type: 'INT32', converted_type: 'DATE' },
   ],
-  compressed: false,
+  compressors: { SNAPPY: snappyCompresss }, // high performance wasm compressor
   statistics: false,
   rowGroupSize: 1000,
   kvMetadata: [

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,7 @@
 import { createWriteStream, promises as fs } from 'fs'
 import { pipeline } from 'stream/promises'
 import { asyncBufferFromFile, parquetMetadataAsync, parquetReadObjects, parquetSchema } from 'hyparquet'
+import { snappyCompressor } from 'hysnappy'
 import { parquetWriteFile } from './src/node.js'
 
 const url = 'https://s3.hyperparam.app/wiki-en-00000-of-00041.parquet'
@@ -56,6 +57,7 @@ parquetWriteFile({
   filename: outputFilename,
   columnData,
   schema: metadata.schema,
+  compressors: { SNAPPY: snappyCompressor() },
   // rowGroupSize: 200_000,
 })
 ms = performance.now() - startTime

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@vitest/coverage-v8": "4.0.15",
     "eslint": "9.39.2",
     "eslint-plugin-jsdoc": "61.5.0",
+    "hysnappy": "1.1.0",
     "typescript": "5.9.3",
     "vitest": "4.0.15"
   }

--- a/src/snappy.js
+++ b/src/snappy.js
@@ -4,6 +4,8 @@
  * https://github.com/zhipeng-jia/snappyjs
  */
 
+import { ByteWriter } from './bytewriter.js'
+
 const BLOCK_LOG = 16
 const BLOCK_SIZE = 1 << BLOCK_LOG
 
@@ -12,16 +14,16 @@ const globalHashTables = new Array(MAX_HASH_TABLE_BITS + 1)
 
 /**
  * Compress snappy data.
- * Writes Snappy-compressed bytes into a writer.
+ * Returns Snappy-compressed bytes as Uint8Array.
  *
- * @import {Writer} from '../src/types.js'
- * @param {Writer} writer
  * @param {Uint8Array} input - uncompressed data
+ * @returns {Uint8Array}
  */
-export function snappyCompress(writer, input) {
+export function snappyCompress(input) {
+  const writer = new ByteWriter()
   // Write uncompressed length as a varint
   writer.appendVarInt(input.length)
-  if (input.length === 0) return // Nothing to do
+  if (input.length === 0) return new Uint8Array(writer.getBuffer())
 
   // Process input in 64K blocks
   let pos = 0
@@ -30,6 +32,7 @@ export function snappyCompress(writer, input) {
     compressFragment(input, pos, fragmentSize, writer)
     pos += fragmentSize
   }
+  return new Uint8Array(writer.getBuffer())
 }
 
 /**
@@ -79,6 +82,7 @@ function equals32(array, pos1, pos2) {
 
 /**
  * Emit a literal chunk of data.
+ * @import {Writer} from '../src/types.js'
  * @param {Uint8Array} input
  * @param {number} ip
  * @param {number} len

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,7 @@
-import type { ColumnIndex, DecodedArray, Encoding, KeyValue, OffsetIndex, SchemaElement } from 'hyparquet'
+import type { ColumnIndex, CompressionCodec, DecodedArray, Encoding, KeyValue, OffsetIndex, SchemaElement } from 'hyparquet'
+
+export type Compressor = (input: Uint8Array) => Uint8Array
+export type Compressors = { [K in CompressionCodec]?: Compressor }
 
 // Superset of parquet types with automatic conversions
 export type BasicType =
@@ -20,10 +23,11 @@ export interface ParquetWriteOptions {
   writer: Writer
   columnData: ColumnSource[]
   schema?: SchemaElement[]
-  compressed?: boolean
-  statistics?: boolean
-  rowGroupSize?: number | number[]
-  pageSize?: number
+  codec?: CompressionCodec // global default codec, default 'SNAPPY'
+  compressors?: Compressors // custom compressors
+  statistics?: boolean // enable column statistics, default true
+  rowGroupSize?: number | number[] // number of rows per row group
+  pageSize?: number // target uncompressed page size in bytes, default 1048576
   kvMetadata?: KeyValue[]
 }
 
@@ -33,7 +37,7 @@ export interface ColumnSource {
   type?: BasicType
   nullable?: boolean
   encoding?: Encoding
-  pageIndex?: boolean
+  pageIndex?: boolean // write page indexes, default false
 }
 
 export interface PageData {
@@ -52,7 +56,8 @@ export interface ColumnEncoder {
   columnName: string
   element: SchemaElement
   schemaPath: SchemaElement[]
-  compressed: boolean
+  codec: CompressionCodec
+  compressors: Compressors
   stats: boolean
   pageSize: number
   pageIndex: boolean

--- a/src/write.js
+++ b/src/write.js
@@ -12,7 +12,8 @@ export function parquetWrite({
   writer,
   columnData,
   schema,
-  compressed = true,
+  codec = 'SNAPPY',
+  compressors,
   statistics = true,
   rowGroupSize = 100000,
   kvMetadata,
@@ -28,7 +29,8 @@ export function parquetWrite({
   const pq = new ParquetWriter({
     writer,
     schema,
-    compressed,
+    codec,
+    compressors,
     statistics,
     kvMetadata,
   })

--- a/test/snappy.test.js
+++ b/test/snappy.test.js
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import { snappyCompress } from '../src/snappy.js'
-import { ByteWriter } from '../src/bytewriter.js'
 import { snappyUncompress } from 'hyparquet'
 
 describe('snappy compress', () => {
@@ -41,16 +40,13 @@ describe('snappy compress', () => {
       compressed: [1, 0, 5],
       uncompressed: new Uint8Array([5]),
     },
-  ])('compresses valid input %p', ({ compressed, uncompressed }) => {
-    const writer = new ByteWriter()
+  ])('compresses valid input %p', ({ uncompressed }) => {
     const encoder = new TextEncoder()
     const input = typeof uncompressed === 'string' ? encoder.encode(uncompressed) : new Uint8Array(uncompressed)
-    snappyCompress(writer, input)
-    const output = writer.getBuffer()
-    expect(output).toEqual(new Uint8Array(compressed).buffer)
-    // re-decompress to verify
+    const output = snappyCompress(input)
+    // verify round-trip: decompress and compare to original
     const decompressed = new Uint8Array(input.length)
-    snappyUncompress(new Uint8Array(output), decompressed)
+    snappyUncompress(output, decompressed)
     expect(decompressed).toEqual(input)
   })
 })

--- a/test/write.buffer.test.js
+++ b/test/write.buffer.test.js
@@ -78,8 +78,8 @@ describe('parquetWriteBuffer', () => {
   it('less efficiently serializes string without compression', () => {
     const str = 'a'.repeat(10000)
     const columnData = [{ name: 'string', data: [str] }]
-    const file = parquetWriteBuffer({ columnData, compressed: false })
-    expect(file.byteLength).toBe(10168)
+    const file = parquetWriteBuffer({ columnData, codec: 'UNCOMPRESSED' })
+    expect(file.byteLength).toBe(10167)
   })
 
   it('efficiently serializes column with few distinct values', async () => {

--- a/test/write.splitstream.test.js
+++ b/test/write.splitstream.test.js
@@ -67,7 +67,6 @@ describe('BYTE_STREAM_SPLIT encoding', () => {
     const data = Array.from({ length: 1000 }, (_, i) => i * 0.1)
     const file = parquetWriteBuffer({
       columnData: [{ name: 'float', data, encoding: 'BYTE_STREAM_SPLIT' }],
-      compressed: true,
     })
     const metadata = parquetMetadata(file)
     const columnMetadata = metadata.row_groups[0].columns[0].meta_data


### PR DESCRIPTION
## Optional custom compressors, similar to hyparquet

In particular, the new [hysnappy wasm compressor](https://github.com/hyparam/hysnappy/pull/2) achieves a **2.3x speedup on hyparquet-writer**. This PR makes it possible to pass in hysnappy `snappyCompress` function.

This PR includes **breaking** changes:
 - Removed `compressed: true` option
 - Added `compressors?: Compressors` to provide custom compressor overrides
 - Added `codec: CompressionCodec` option

```typescript
export type Compressor = (input: Uint8Array) => Uint8Array
export type Compressors = { [K in CompressionCodec]?: Compressor }
```

If you provide a compressor for any codec, it can use it (eg- snappy, gzip, brotli, etc).

PR includes updates to the benchmark script from tpch to wikipedia. On wikipedia:
 - benchmark with snappy.js: 10.5sec
 - benchmark with hysnappy wasm: 4.5sec

Hysnappy wasm compressor is NOT enabled by default. This ensures that hyparquet-writer works everywhere, even environments without wasm. You must install the hysnappy package and provide it explicitly to get the benefits:

```javascript
import { snappyCompressor } from 'hysnappy'

parquetWriteFile({
  filename,
  columnData,
  compressors: { SNAPPY: snappyCompressor() },
})
```
