### PR TITLE
Fix first_row_index on repeated values

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -45,7 +45,6 @@ export interface PageData {
   values: DecodedArray
   definitionLevels: number[]
   repetitionLevels: number[]
-  numNulls: number
   maxDefinitionLevel: number
 }
 


### PR DESCRIPTION
Fix the calculation of `first_row_index` when there are repeated values (list/struct).

To compute this we count where rep level is zero on prior pages.

While I was at it I found some opportunities for improvement:
- refactored how `num_nulls` is computed to save several traversals of the data
- remove `numNulls` from `PageData`
- don't pass redundant `values` to functions that already accept `PageData`
- don't filter on arrays with no nulls
- fix `ColumnIndex` type (`min_values` should always be `Uint8Array[]`)
