### PR TITLE
Async-capable Writer: finish() and flush()

### DIFF
--- a/src/parquet-writer.js
+++ b/src/parquet-writer.js
@@ -113,6 +113,8 @@ ParquetWriter.prototype.write = function({ columnData, rowGroupSize = [1000, 100
 
 /**
  * Finish writing the file.
+ *
+ * @returns {void | Promise<void>}
  */
 ParquetWriter.prototype.finish = function() {
   // Write all indexes at end of file
@@ -135,7 +137,7 @@ ParquetWriter.prototype.finish = function() {
 
   // write footer PAR1
   this.writer.appendUint32(0x31524150)
-  this.writer.finish()
+  return this.writer.finish()
 }
 
 /**

--- a/src/parquet-writer.js
+++ b/src/parquet-writer.js
@@ -44,71 +44,86 @@ export function ParquetWriter({ writer, schema, codec = 'SNAPPY', compressors, s
 /**
  * Write data to the file.
  * Will split data into row groups of the specified size.
+ * Calls writer.flush() (if defined) after each row group; if it returns a
+ * Promise, subsequent row groups await it before encoding more data.
  *
  * @param {object} options
  * @param {ColumnSource[]} options.columnData
  * @param {number | number[]} [options.rowGroupSize]
  * @param {number} [options.pageSize]
+ * @returns {void | Promise<void>}
  */
 ParquetWriter.prototype.write = function({ columnData, rowGroupSize = [1000, 100000], pageSize = 1048576 }) {
   const columnDataRows = columnData[0]?.data?.length || 0
+  /** @type {Promise<void> | undefined} */
+  let pending
   for (const { groupStartIndex, groupSize } of groupIterator({ columnDataRows, rowGroupSize })) {
-    const groupStartOffset = this.writer.offset
-    /** @type {ColumnChunk[]} */
-    const columns = []
+    const writeGroup = () => {
+      const groupStartOffset = this.writer.offset
+      /** @type {ColumnChunk[]} */
+      const columns = []
 
-    // write columns
-    for (let j = 0; j < columnData.length; j++) {
-      const { name, data, encoding, columnIndex = false, offsetIndex = true } = columnData[j]
+      // write columns
+      for (let j = 0; j < columnData.length; j++) {
+        const { name, data, encoding, columnIndex = false, offsetIndex = true } = columnData[j]
 
-      // Spec: if ColumnIndex is present, OffsetIndex must also be present
-      if (columnIndex && !offsetIndex) {
-        throw new Error('parquet ColumnIndex cannot be present without OffsetIndex')
-      }
-      if (data.length !== columnDataRows) {
-        throw new Error('parquet columns must have the same length')
-      }
-
-      const groupData = data.slice(groupStartIndex, groupStartIndex + groupSize)
-      const columnPath = getSchemaPath(this.schema, [name])
-      const leafPaths = getLeafSchemaPaths(columnPath)
-
-      for (const leafPath of leafPaths) {
-        const schemaPath = leafPath.map(node => node.element)
-
-        /** @type {ColumnEncoder} */
-        const column = {
-          columnName: schemaPath.slice(1).map(s => s.name).join('.'),
-          element: schemaPath[schemaPath.length - 1],
-          schemaPath,
-          codec: this.codec,
-          compressors: this.compressors,
-          stats: this.statistics,
-          pageSize,
-          columnIndex,
-          offsetIndex,
-          encoding,
+        // Spec: if ColumnIndex is present, OffsetIndex must also be present
+        if (columnIndex && !offsetIndex) {
+          throw new Error('parquet ColumnIndex cannot be present without OffsetIndex')
+        }
+        if (data.length !== columnDataRows) {
+          throw new Error('parquet columns must have the same length')
         }
 
-        const pageData = encodeNestedValues(leafPath, groupData)
-        const result = writeColumn({
-          writer: this.writer,
-          column,
-          pageData,
-        })
+        const groupData = data.slice(groupStartIndex, groupStartIndex + groupSize)
+        const columnPath = getSchemaPath(this.schema, [name])
+        const leafPaths = getLeafSchemaPaths(columnPath)
 
-        columns.push(result.chunk)
-        this.pendingIndexes.push(result)
+        for (const leafPath of leafPaths) {
+          const schemaPath = leafPath.map(node => node.element)
+
+          /** @type {ColumnEncoder} */
+          const column = {
+            columnName: schemaPath.slice(1).map(s => s.name).join('.'),
+            element: schemaPath[schemaPath.length - 1],
+            schemaPath,
+            codec: this.codec,
+            compressors: this.compressors,
+            stats: this.statistics,
+            pageSize,
+            columnIndex,
+            offsetIndex,
+            encoding,
+          }
+
+          const pageData = encodeNestedValues(leafPath, groupData)
+          const result = writeColumn({
+            writer: this.writer,
+            column,
+            pageData,
+          })
+
+          columns.push(result.chunk)
+          this.pendingIndexes.push(result)
+        }
       }
-    }
 
-    this.num_rows += BigInt(groupSize)
-    this.row_groups.push({
-      columns,
-      total_byte_size: BigInt(this.writer.offset - groupStartOffset),
-      num_rows: BigInt(groupSize),
-    })
+      this.num_rows += BigInt(groupSize)
+      this.row_groups.push({
+        columns,
+        total_byte_size: BigInt(this.writer.offset - groupStartOffset),
+        num_rows: BigInt(groupSize),
+      })
+      return this.writer.flush?.()
+    }
+    if (pending) {
+      pending = pending.then(writeGroup)
+    } else {
+      const r = writeGroup()
+      if (r) pending = Promise.resolve(r)
+    }
   }
+  return pending
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,7 +74,7 @@ export interface Writer {
   offset: number // total bytes written
 
   ensure(size: number): void
-  finish(): void
+  finish(): void | Promise<void>
   getBuffer(): ArrayBuffer
   getBytes(): Uint8Array
   appendUint8(value: number): void

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,6 +74,7 @@ export interface Writer {
   offset: number // total bytes written
 
   ensure(size: number): void
+  flush?(): void | Promise<void>
   finish(): void | Promise<void>
   getBuffer(): ArrayBuffer
   getBytes(): Uint8Array

--- a/src/write.js
+++ b/src/write.js
@@ -38,12 +38,12 @@ export function parquetWrite({
     statistics,
     kvMetadata,
   })
-  pq.write({
+  const w = pq.write({
     columnData,
     rowGroupSize,
     pageSize,
   })
-  return pq.finish()
+  return w ? w.then(() => pq.finish()) : pq.finish()
 }
 
 /**

--- a/src/write.js
+++ b/src/write.js
@@ -10,6 +10,7 @@ import { schemaFromColumnData } from './schema.js'
  * Write data as parquet to a file or stream.
  *
  * @param {ParquetWriteOptions} options
+ * @returns {void | Promise<void>}
  */
 export function parquetWrite({
   writer,
@@ -42,7 +43,7 @@ export function parquetWrite({
     rowGroupSize,
     pageSize,
   })
-  pq.finish()
+  return pq.finish()
 }
 
 /**

--- a/test/write.async.test.js
+++ b/test/write.async.test.js
@@ -1,0 +1,30 @@
+import { parquetReadObjects } from 'hyparquet'
+import { describe, expect, it } from 'vitest'
+import { ByteWriter, parquetWrite } from '../src/index.js'
+import { exampleData } from './example.js'
+
+describe('parquetWrite async finish', () => {
+  it('awaits a writer whose finish() returns a Promise', async () => {
+    const writer = new ByteWriter()
+    let finished = false
+    writer.finish = async () => {
+      await Promise.resolve()
+      finished = true
+    }
+
+    const result = parquetWrite({ writer, columnData: exampleData })
+    expect(result).toBeInstanceOf(Promise)
+    expect(finished).toBe(false)
+    await result
+    expect(finished).toBe(true)
+
+    const output = await parquetReadObjects({ file: writer.getBuffer() })
+    expect(output).toHaveLength(4)
+  })
+
+  it('stays synchronous when writer.finish() is sync', () => {
+    const writer = new ByteWriter()
+    const result = parquetWrite({ writer, columnData: exampleData })
+    expect(result).toBeUndefined()
+  })
+})

--- a/test/write.async.test.js
+++ b/test/write.async.test.js
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest'
 import { ByteWriter, parquetWrite } from '../src/index.js'
 import { exampleData } from './example.js'
 
+/**
+ * @import {Writer} from '../src/types.js'
+ */
+
 describe('parquetWrite async finish', () => {
   it('awaits a writer whose finish() returns a Promise', async () => {
     const writer = new ByteWriter()
@@ -26,5 +30,33 @@ describe('parquetWrite async finish', () => {
     const writer = new ByteWriter()
     const result = parquetWrite({ writer, columnData: exampleData })
     expect(result).toBeUndefined()
+  })
+
+  it('calls flush() between row groups and awaits returned promises', async () => {
+    /** @type {Writer} */
+    const writer = new ByteWriter()
+    /** @type {number[]} */
+    const flushOffsets = []
+    let resolved = 0
+    writer.flush = async () => {
+      flushOffsets.push(writer.offset)
+      await Promise.resolve()
+      resolved++
+    }
+
+    const columnData = [{ name: 'n', data: Array.from({ length: 2500 }, (_, i) => i) }]
+    // rowGroupSize=1000 → 3 row groups → 3 flush calls
+    const result = parquetWrite({ writer, columnData, rowGroupSize: 1000 })
+    expect(result).toBeInstanceOf(Promise)
+    await result
+
+    expect(flushOffsets).toHaveLength(3)
+    expect(resolved).toBe(3)
+    // each flush sees a strictly larger offset (data accumulated between groups)
+    expect(flushOffsets[0]).toBeLessThan(flushOffsets[1])
+    expect(flushOffsets[1]).toBeLessThan(flushOffsets[2])
+
+    const output = await parquetReadObjects({ file: writer.getBuffer() })
+    expect(output).toHaveLength(2500)
   })
 })


### PR DESCRIPTION
The Writer interface was sync, so streaming to a network sink meant buffering the whole file in memory. This PR loosens `finish()` to be optionally async, plus an optional `flush()` hook between row groups.

- Widen `Writer.finish()` to `void | Promise<void>` so writers can await async sinks (HTTP uploads, S3 multipart, etc.) without buffering the whole file in memory.
- Add optional `Writer.flush?(): void | Promise<void>`, called by `ParquetWriter` after each row group — gives streaming writers a natural backpressure point instead of forcing them to track byte counts themselves.
- `parquetWrite` returns `void | Promise<void>` via manual promise chaining: only writers that actually return a Promise upgrade the pipeline to async. `ByteWriter`, `fileWriter`, `parquetWriteBuffer`, and `parquetWriteFile` stay fully synchronous, no existing callsite needs `await`.
