### PR TITLE
Bloom Filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "hyparquet": "1.25.8"
+    "hyparquet": "1.26.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.28.6",

--- a/src/bloom.js
+++ b/src/bloom.js
@@ -3,6 +3,12 @@
 // Insertion sets one bit per word, chosen by salting the low 32 bits of an xxhash64.
 // Membership requires all 8 bits to be set; misses are exact, hits are probabilistic.
 
+import { serializeTCompactProtocol } from './thrift.js'
+
+/**
+ * @import {Writer} from '../src/types.js'
+ */
+
 const SALT = new Uint32Array([
   0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d,
   0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31,
@@ -117,4 +123,27 @@ export function optimalNumBytes(ndv, fpp) {
 export function createBloomFilter(ndv, fpp = 0.01) {
   const numBytes = optimalNumBytes(ndv, fpp)
   return new Uint32Array(numBytes >> 2)
+}
+
+/**
+ * Write a parquet bloom filter: BloomFilterHeader thrift struct followed by
+ * the raw little-endian bytes of the SBBF blocks. Always uses BLOCK / XXHASH /
+ * UNCOMPRESSED, the only variants parquet currently defines.
+ *
+ * @param {Writer} writer
+ * @param {Uint32Array} blocks bloom filter words (8 * numBlocks long)
+ */
+export function writeBloomFilter(writer, blocks) {
+  if (blocks.length % 8 !== 0) {
+    throw new Error(`bloom filter block count must be a multiple of 8 uint32 words, got ${blocks.length}`)
+  }
+  serializeTCompactProtocol(writer, {
+    field_1: blocks.byteLength, // numBytes
+    field_2: { field_1: {} }, // algorithm: SplitBlockAlgorithm
+    field_3: { field_1: {} }, // hash: XxHash
+    field_4: { field_1: {} }, // compression: Uncompressed
+  })
+  for (let i = 0; i < blocks.length; i++) {
+    writer.appendUint32(blocks[i])
+  }
 }

--- a/src/bloom.js
+++ b/src/bloom.js
@@ -1,0 +1,120 @@
+// Split Block Bloom Filter (https://github.com/apache/parquet-format/blob/master/BloomFilter.md)
+// A bloom filter is a sequence of 32-byte blocks. Each block holds 8 little-endian uint32 words.
+// Insertion sets one bit per word, chosen by salting the low 32 bits of an xxhash64.
+// Membership requires all 8 bits to be set; misses are exact, hits are probabilistic.
+
+const SALT = new Uint32Array([
+  0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d,
+  0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31,
+])
+
+const BYTES_PER_BLOCK = 32
+const MIN_BYTES = 32 // one block
+const MAX_BYTES = 128 * 1024 * 1024 // parquet-mr default cap
+
+/**
+ * Map the high 32 bits of a hash to a block index in [0, numBlocks).
+ *
+ * @param {bigint} hash
+ * @param {number} numBlocks
+ * @returns {number}
+ */
+function blockIndex(hash, numBlocks) {
+  return Number((hash >> 32n) * BigInt(numBlocks) >> 32n)
+}
+
+/**
+ * Per-block mask: 8 uint32 words, each with a single bit set at position `(low32 * SALT[i]) >> 27`.
+ *
+ * @param {bigint} hash
+ * @returns {Uint32Array}
+ */
+function blockMask(hash) {
+  const m = new Uint32Array(8)
+  const low = Number(hash & 0xffffffffn) | 0
+  for (let i = 0; i < 8; i++) {
+    m[i] = 1 << (Math.imul(low, SALT[i]) >>> 27)
+  }
+  return m
+}
+
+/**
+ * Insert a hash into a Split Block Bloom Filter.
+ *
+ * @param {Uint32Array} blocks bloom filter words (8 * numBlocks long)
+ * @param {bigint} hash 64-bit xxhash of the parquet-plain-encoded value
+ */
+export function sbbfInsert(blocks, hash) {
+  const offset = blockIndex(hash, blocks.length >> 3) << 3
+  const m = blockMask(hash)
+  for (let i = 0; i < 8; i++) {
+    blocks[offset + i] |= m[i]
+  }
+}
+
+/**
+ * Test whether a hash might be present in a Split Block Bloom Filter.
+ * False positives are possible; false negatives are not.
+ *
+ * @param {Uint32Array} blocks bloom filter words (8 * numBlocks long)
+ * @param {bigint} hash 64-bit xxhash of the parquet-plain-encoded value
+ * @returns {boolean}
+ */
+export function sbbfContains(blocks, hash) {
+  const offset = blockIndex(hash, blocks.length >> 3) << 3
+  const m = blockMask(hash)
+  for (let i = 0; i < 8; i++) {
+    if ((blocks[offset + i] & m[i]) === 0) return false
+  }
+  return true
+}
+
+/**
+ * Round up to the next power of two (32-bit).
+ *
+ * @param {number} n
+ * @returns {number}
+ */
+function nextPowerOfTwo(n) {
+  let p = 1
+  while (p < n) p <<= 1
+  return p
+}
+
+/**
+ * Optimal SBBF size in bytes for a given number of distinct values and
+ * target false-positive probability. Matches parquet-mr's BlockSplitBloomFilter:
+ * derives bits from m = -8 * ndv / ln(1 - p^(1/8)), rounds up to a whole block,
+ * and snaps to the next power of two below 1024 bits.
+ *
+ * @param {number} ndv expected number of distinct values
+ * @param {number} fpp target false positive probability, in (0, 1)
+ * @returns {number} bloom filter size in bytes (multiple of 32)
+ */
+export function optimalNumBytes(ndv, fpp) {
+  if (!(fpp > 0 && fpp < 1)) throw new Error(`bloom filter fpp must be in (0, 1), got ${fpp}`)
+  if (!(ndv >= 0)) throw new Error(`bloom filter ndv must be >= 0, got ${ndv}`)
+  const m = -8 * ndv / Math.log(1 - fpp ** (1 / 8))
+  let numBits = Math.ceil(m)
+  if (!isFinite(numBits) || numBits > MAX_BYTES << 3) numBits = MAX_BYTES << 3
+  // Round up to whole 32-byte blocks
+  const blockBits = BYTES_PER_BLOCK << 3
+  numBits = Math.ceil(numBits / blockBits) * blockBits
+  let numBytes = numBits >> 3
+  if (numBytes < MIN_BYTES) numBytes = MIN_BYTES
+  // Power-of-two snap below 1024 bytes (matches parquet-mr behavior)
+  if (numBytes < 1024) numBytes = nextPowerOfTwo(numBytes)
+  return numBytes
+}
+
+/**
+ * Allocate a zeroed Split Block Bloom Filter sized for the given NDV and FPP.
+ *
+ * @param {number} ndv expected number of distinct values
+ * @param {number} [fpp] target false positive probability, default 0.01
+ * @returns {Uint32Array} blocks (numBytes / 4 uint32 words)
+ */
+export function createBloomFilter(ndv, fpp = 0.01) {
+  const numBytes = optimalNumBytes(ndv, fpp)
+  return new Uint32Array(numBytes >> 2)
+}

--- a/src/bloom.js
+++ b/src/bloom.js
@@ -8,7 +8,7 @@ import { serializeTCompactProtocol } from './thrift.js'
 
 /**
  * @import {SchemaElement} from 'hyparquet'
- * @import {Writer} from '../src/types.js'
+ * @import {PageIndexes, Writer} from '../src/types.js'
  */
 
 const SALT = new Uint32Array([
@@ -189,5 +189,24 @@ export function writeBloomFilter(writer, blocks) {
   })
   for (let i = 0; i < blocks.length; i++) {
     writer.appendUint32(blocks[i])
+  }
+}
+
+/**
+ * Write all pending bloom filters in a contiguous block and patch each chunk's
+ * meta_data.bloom_filter_offset / bloom_filter_length so readers can find them.
+ * Clustering matches parquet-mr's tail placement: a reader fetching the footer
+ * region can pull every bloom in one range request.
+ *
+ * @param {Writer} writer
+ * @param {PageIndexes[]} pageIndexes
+ */
+export function writeBlooms(writer, pageIndexes) {
+  for (const { chunk, bloomFilter } of pageIndexes) {
+    if (!bloomFilter || !chunk.meta_data) continue
+    const offset = writer.offset
+    writeBloomFilter(writer, bloomFilter)
+    chunk.meta_data.bloom_filter_offset = BigInt(offset)
+    chunk.meta_data.bloom_filter_length = writer.offset - offset
   }
 }

--- a/src/bloom.js
+++ b/src/bloom.js
@@ -3,9 +3,11 @@
 // Insertion sets one bit per word, chosen by salting the low 32 bits of an xxhash64.
 // Membership requires all 8 bits to be set; misses are exact, hits are probabilistic.
 
+import { hashParquetValue } from 'hyparquet/src/bloom.js'
 import { serializeTCompactProtocol } from './thrift.js'
 
 /**
+ * @import {SchemaElement} from 'hyparquet'
  * @import {Writer} from '../src/types.js'
  */
 
@@ -123,6 +125,48 @@ export function optimalNumBytes(ndv, fpp) {
 export function createBloomFilter(ndv, fpp = 0.01) {
   const numBytes = optimalNumBytes(ndv, fpp)
   return new Uint32Array(numBytes >> 2)
+}
+
+/**
+ * Collects distinct hashes of column values and finalizes them into an SBBF
+ * sized for the actual distinct count. `finalize` returns `undefined` if any
+ * non-null value was unhashable (the filter would have false negatives), if
+ * no values were seen, or if the optimal size exceeds `maxBytes`.
+ */
+export class BloomBuilder {
+  /**
+   * @param {SchemaElement} element
+   * @param {{ fpp?: number, maxBytes?: number }} [options]
+   */
+  constructor(element, { fpp = 0.01, maxBytes = 1024 * 1024 } = {}) {
+    this.element = element
+    this.fpp = fpp
+    this.maxBytes = maxBytes
+    /** @type {Set<bigint>} */
+    this.hashes = new Set()
+    this.skipped = 0
+  }
+
+  /** @param {any} value */
+  insert(value) {
+    if (value === null || value === undefined) return
+    const h = hashParquetValue(value, this.element)
+    if (h === undefined) {
+      this.skipped++
+      return
+    }
+    this.hashes.add(h)
+  }
+
+  /** @returns {Uint32Array | undefined} */
+  finalize() {
+    if (this.skipped > 0 || this.hashes.size === 0) return undefined
+    const numBytes = optimalNumBytes(this.hashes.size, this.fpp)
+    if (numBytes > this.maxBytes) return undefined
+    const blocks = new Uint32Array(numBytes >> 2)
+    for (const h of this.hashes) sbbfInsert(blocks, h)
+    return blocks
+  }
 }
 
 /**

--- a/src/column.js
+++ b/src/column.js
@@ -1,3 +1,4 @@
+import { BloomBuilder } from './bloom.js'
 import { ByteWriter } from './bytewriter.js'
 import { writeDataPageV2, writePageHeader } from './datapage.js'
 import { geospatialStatistics } from './geospatial.js'
@@ -17,7 +18,7 @@ import { unconvert, unconvertMinMax } from './unconvert.js'
  * @param {Writer} options.writer
  * @param {ColumnEncoder} options.column
  * @param {PageData} options.pageData
- * @returns {{ chunk: ColumnChunk, columnIndex?: ColumnIndex, offsetIndex?: OffsetIndex }}
+ * @returns {{ chunk: ColumnChunk, columnIndex?: ColumnIndex, offsetIndex?: OffsetIndex, bloomFilter?: Uint32Array }}
  */
 export function writeColumn({ writer, column, pageData }) {
   const { columnName, element, schemaPath, stats, pageSize, encoding: userEncoding } = column
@@ -34,6 +35,15 @@ export function writeColumn({ writer, column, pageData }) {
   // Compute statistics
   const statistics = stats ? getStatistics(values) : undefined
   const geospatial_statistics = stats && isGeospatial ? geospatialStatistics(values) : undefined
+
+  // Build bloom filter from original values (hashParquetValue reads schema info from element)
+  let bloomFilter
+  if (column.bloomFilter) {
+    const opts = typeof column.bloomFilter === 'object' ? column.bloomFilter : undefined
+    const builder = new BloomBuilder(element, opts)
+    for (const v of values) builder.insert(v)
+    bloomFilter = builder.finalize()
+  }
 
   // dictionary encoding
   /** @type {bigint | undefined} */
@@ -183,6 +193,7 @@ export function writeColumn({ writer, column, pageData }) {
     },
     columnIndex,
     offsetIndex,
+    bloomFilter,
   }
 }
 

--- a/src/parquet-writer.js
+++ b/src/parquet-writer.js
@@ -1,4 +1,5 @@
 import { getSchemaPath } from 'hyparquet/src/schema.js'
+import { writeBlooms } from './bloom.js'
 import { writeColumn } from './column.js'
 import { encodeNestedValues } from './dremel.js'
 import { writeIndexes } from './indexes.js'
@@ -66,7 +67,7 @@ ParquetWriter.prototype.write = function({ columnData, rowGroupSize = [1000, 100
 
       // write columns
       for (let j = 0; j < columnData.length; j++) {
-        const { name, data, encoding, columnIndex = false, offsetIndex = true, shredding } = columnData[j]
+        const { name, data, encoding, columnIndex = false, offsetIndex = true, shredding, bloomFilter } = columnData[j]
 
         // Spec: if ColumnIndex is present, OffsetIndex must also be present
         if (columnIndex && !offsetIndex) {
@@ -104,6 +105,7 @@ ParquetWriter.prototype.write = function({ columnData, rowGroupSize = [1000, 100
             columnIndex,
             offsetIndex,
             encoding,
+            bloomFilter,
           }
 
           const pageData = encodeNestedValues(leafPath, rows)
@@ -144,6 +146,8 @@ ParquetWriter.prototype.write = function({ columnData, rowGroupSize = [1000, 100
 ParquetWriter.prototype.finish = function() {
   // Write all indexes at end of file
   writeIndexes(this.writer, this.pendingIndexes)
+  // Bloom filters cluster after indexes so pushdown readers fetch them in one range
+  writeBlooms(this.writer, this.pendingIndexes)
 
   // write metadata
   /** @type {FileMetaData} */

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -41,6 +41,7 @@ export interface ColumnSource {
   columnIndex?: boolean // write column indexes, default false
   offsetIndex?: boolean // write offset indexes, default true
   shredding?: true | Record<string, BasicType> // variant shredding config
+  bloomFilter?: boolean | BloomFilterOptions // write bloom filter, default false
 }
 
 export interface PageData {
@@ -48,6 +49,11 @@ export interface PageData {
   definitionLevels: number[]
   repetitionLevels: number[]
   maxDefinitionLevel: number
+}
+
+export interface BloomFilterOptions {
+  fpp?: number // false positive probability, default 0.01
+  maxBytes?: number // skip emission above this size, default 1 MiB
 }
 
 export interface ColumnEncoder {
@@ -62,12 +68,14 @@ export interface ColumnEncoder {
   columnIndex: boolean
   offsetIndex: boolean
   encoding?: Encoding // user-specified encoding
+  bloomFilter?: boolean | BloomFilterOptions
 }
 
 export interface PageIndexes {
   chunk: ColumnChunk
   columnIndex?: ColumnIndex
   offsetIndex?: OffsetIndex
+  bloomFilter?: Uint32Array // finalized SBBF blocks
 }
 
 export interface Writer {

--- a/test/bloom.test.js
+++ b/test/bloom.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { hashParquetValue } from 'hyparquet/src/bloom.js'
+import { xxhash64 } from 'hyparquet/src/xxhash.js'
+import { createBloomFilter, optimalNumBytes, sbbfContains, sbbfInsert } from '../src/bloom.js'
+
+const textEncoder = new TextEncoder()
+
+describe('optimalNumBytes', () => {
+  it('returns the minimum 32 bytes for tiny NDV', () => {
+    expect(optimalNumBytes(1, 0.01)).toBe(32)
+  })
+
+  it('grows with NDV and snaps below 1024 to a power of two', () => {
+    const small = optimalNumBytes(100, 0.01)
+    const big = optimalNumBytes(10000, 0.01)
+    expect(small).toBeGreaterThanOrEqual(32)
+    expect(big).toBeGreaterThan(small)
+    // Below 1024 should be a power of two
+    if (small < 1024) expect(small & small - 1).toBe(0)
+  })
+
+  it('always returns a multiple of 32', () => {
+    for (const ndv of [1, 10, 100, 1000, 10000, 100000]) {
+      expect(optimalNumBytes(ndv, 0.01) % 32).toBe(0)
+    }
+  })
+
+  it('looser FPP yields a smaller (or equal) filter', () => {
+    const tight = optimalNumBytes(10000, 0.001)
+    const loose = optimalNumBytes(10000, 0.1)
+    expect(loose).toBeLessThanOrEqual(tight)
+  })
+
+  it('rejects fpp out of range', () => {
+    expect(() => optimalNumBytes(100, 0)).toThrow()
+    expect(() => optimalNumBytes(100, 1)).toThrow()
+  })
+})
+
+describe('createBloomFilter', () => {
+  it('returns a zeroed Uint32Array sized by optimalNumBytes', () => {
+    const bf = createBloomFilter(1000, 0.01)
+    expect(bf).toBeInstanceOf(Uint32Array)
+    expect(bf.byteLength).toBe(optimalNumBytes(1000, 0.01))
+    expect(bf.every(w => w === 0)).toBe(true)
+  })
+
+  it('defaults fpp to 0.01', () => {
+    expect(createBloomFilter(1000).byteLength).toBe(optimalNumBytes(1000, 0.01))
+  })
+})
+
+describe('sbbfInsert / sbbfContains', () => {
+  it('contains every inserted hash (no false negatives)', () => {
+    const bf = createBloomFilter(1000, 0.01)
+    /** @type {bigint[]} */
+    const hashes = []
+    for (let i = 0; i < 500; i++) {
+      const h = xxhash64(textEncoder.encode(`in-${i}`))
+      hashes.push(h)
+      sbbfInsert(bf, h)
+    }
+    for (const h of hashes) {
+      expect(sbbfContains(bf, h)).toBe(true)
+    }
+  })
+
+  it('false-positive rate is roughly bounded by the target FPP', () => {
+    const ndv = 1000
+    const fpp = 0.01
+    const bf = createBloomFilter(ndv, fpp)
+    for (let i = 0; i < ndv; i++) {
+      sbbfInsert(bf, xxhash64(textEncoder.encode(`in-${i}`)))
+    }
+    let fp = 0
+    const probes = 10000
+    for (let i = 0; i < probes; i++) {
+      if (sbbfContains(bf, xxhash64(textEncoder.encode(`probe-${i}`)))) fp++
+    }
+    expect(fp / probes).toBeLessThan(fpp * 3)
+  })
+
+  it('an empty filter contains no hash', () => {
+    const bf = createBloomFilter(100, 0.01)
+    expect(sbbfContains(bf, 0n)).toBe(false)
+    expect(sbbfContains(bf, 0xdeadbeefdeadbeefn)).toBe(false)
+  })
+})
+
+describe('hashParquetValue', () => {
+  it('hashes BOOLEAN as a single byte', () => {
+    expect(hashParquetValue(true, { name: 'b', type: 'BOOLEAN' })).toBeTypeOf('bigint')
+    expect(hashParquetValue(false, { name: 'b', type: 'BOOLEAN' }))
+      .not.toBe(hashParquetValue(true, { name: 'b', type: 'BOOLEAN' }))
+  })
+
+  it('hashes INT32 as a little-endian 4-byte value', () => {
+    const h = hashParquetValue(42, { name: 'i', type: 'INT32' })
+    expect(h).toBeTypeOf('bigint')
+  })
+
+  it('hashes INT64 from bigint and from safe number identically', () => {
+    const a = hashParquetValue(42n, { name: 'i', type: 'INT64' })
+    const b = hashParquetValue(42, { name: 'i', type: 'INT64' })
+    expect(a).toBe(b)
+  })
+
+  it('hashes BYTE_ARRAY strings via UTF-8', () => {
+    const h = hashParquetValue('abc', { name: 's', type: 'BYTE_ARRAY' })
+    expect(h).toBe(0x44bc2cf5ad770999n)
+  })
+
+  it('returns undefined for null/undefined', () => {
+    expect(hashParquetValue(null, { name: 's', type: 'BYTE_ARRAY' })).toBeUndefined()
+    expect(hashParquetValue(undefined, { name: 's', type: 'BYTE_ARRAY' })).toBeUndefined()
+  })
+
+  it('returns undefined for type mismatches', () => {
+    expect(hashParquetValue('not-a-number', { name: 'i', type: 'INT32' })).toBeUndefined()
+    expect(hashParquetValue(1.5, { name: 'i', type: 'INT32' })).toBeUndefined()
+    expect(hashParquetValue(123, { name: 's', type: 'BYTE_ARRAY' })).toBeUndefined()
+  })
+
+  it('returns undefined for lossy logical types (DATE, TIMESTAMP, DECIMAL, UUID, ...)', () => {
+    expect(hashParquetValue(1, { name: 'd', type: 'INT32', converted_type: 'DATE' })).toBeUndefined()
+    expect(hashParquetValue(1n, { name: 't', type: 'INT64', converted_type: 'TIMESTAMP_MILLIS' })).toBeUndefined()
+    expect(hashParquetValue('{}', { name: 'j', type: 'BYTE_ARRAY', converted_type: 'JSON' })).toBeUndefined()
+    expect(hashParquetValue(new Uint8Array(16), { name: 'u', type: 'FIXED_LEN_BYTE_ARRAY', logical_type: { type: 'UUID' } })).toBeUndefined()
+  })
+})

--- a/test/bloom.test.js
+++ b/test/bloom.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { hashParquetValue } from 'hyparquet/src/bloom.js'
+import { hashParquetValue, readBloomFilter } from 'hyparquet/src/bloom.js'
 import { xxhash64 } from 'hyparquet/src/xxhash.js'
-import { createBloomFilter, optimalNumBytes, sbbfContains, sbbfInsert } from '../src/bloom.js'
+import { ByteWriter } from '../src/bytewriter.js'
+import { createBloomFilter, optimalNumBytes, sbbfContains, sbbfInsert, writeBloomFilter } from '../src/bloom.js'
 
 const textEncoder = new TextEncoder()
 
@@ -84,6 +85,38 @@ describe('sbbfInsert / sbbfContains', () => {
     const bf = createBloomFilter(100, 0.01)
     expect(sbbfContains(bf, 0n)).toBe(false)
     expect(sbbfContains(bf, 0xdeadbeefdeadbeefn)).toBe(false)
+  })
+})
+
+describe('writeBloomFilter', () => {
+  it('round-trips through hyparquet readBloomFilter', () => {
+    const bf = createBloomFilter(1000, 0.01)
+    /** @type {bigint[]} */
+    const hashes = []
+    for (let i = 0; i < 200; i++) {
+      const h = xxhash64(textEncoder.encode(`v-${i}`))
+      hashes.push(h)
+      sbbfInsert(bf, h)
+    }
+    const writer = new ByteWriter()
+    writeBloomFilter(writer, bf)
+
+    const bytes = writer.getBytes()
+    const reader = { view: new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength), offset: 0 }
+    const parsed = readBloomFilter(reader)
+
+    expect(parsed).toBeDefined()
+    expect(parsed?.numBytes).toBe(bf.byteLength)
+    expect(reader.offset).toBe(bytes.byteLength)
+    expect(parsed?.blocks).toEqual(bf)
+    for (const h of hashes) {
+      expect(sbbfContains(parsed?.blocks ?? new Uint32Array(0), h)).toBe(true)
+    }
+  })
+
+  it('rejects block arrays that are not a multiple of 8 words', () => {
+    const writer = new ByteWriter()
+    expect(() => writeBloomFilter(writer, new Uint32Array(7))).toThrow()
   })
 })
 

--- a/test/bloom.test.js
+++ b/test/bloom.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { hashParquetValue, readBloomFilter } from 'hyparquet/src/bloom.js'
 import { xxhash64 } from 'hyparquet/src/xxhash.js'
 import { ByteWriter } from '../src/bytewriter.js'
-import { createBloomFilter, optimalNumBytes, sbbfContains, sbbfInsert, writeBloomFilter } from '../src/bloom.js'
+import { BloomBuilder, createBloomFilter, optimalNumBytes, sbbfContains, sbbfInsert, writeBloomFilter } from '../src/bloom.js'
 
 const textEncoder = new TextEncoder()
 
@@ -117,6 +117,59 @@ describe('writeBloomFilter', () => {
   it('rejects block arrays that are not a multiple of 8 words', () => {
     const writer = new ByteWriter()
     expect(() => writeBloomFilter(writer, new Uint32Array(7))).toThrow()
+  })
+})
+
+describe('BloomBuilder', () => {
+  it('collects values and finalizes to a filter containing each', () => {
+    const builder = new BloomBuilder({ name: 's', type: 'BYTE_ARRAY' })
+    const values = ['alpha', 'beta', 'gamma', 'beta', 'delta']
+    for (const v of values) builder.insert(v)
+    const blocks = builder.finalize()
+    expect(blocks).toBeDefined()
+    for (const v of values) {
+      const h = hashParquetValue(v, { name: 's', type: 'BYTE_ARRAY' }) ?? 0n
+      expect(sbbfContains(blocks ?? new Uint32Array(0), h)).toBe(true)
+    }
+  })
+
+  it('skips null and undefined without disabling the filter', () => {
+    const builder = new BloomBuilder({ name: 'i', type: 'INT32' })
+    builder.insert(null)
+    builder.insert(undefined)
+    builder.insert(1)
+    builder.insert(2)
+    const blocks = builder.finalize()
+    expect(blocks).toBeDefined()
+  })
+
+  it('sizes the filter for the distinct count, not the insert count', () => {
+    const builder = new BloomBuilder({ name: 'i', type: 'INT32' }, { fpp: 0.01 })
+    for (let i = 0; i < 10000; i++) builder.insert(i % 50) // 50 distinct
+    const blocks = builder.finalize()
+    expect(blocks?.byteLength).toBe(optimalNumBytes(50, 0.01))
+  })
+
+  it('returns undefined when no values were inserted', () => {
+    const builder = new BloomBuilder({ name: 's', type: 'BYTE_ARRAY' })
+    expect(builder.finalize()).toBeUndefined()
+  })
+
+  it('returns undefined when any non-null value is unhashable (would be a false negative)', () => {
+    // INT32 column with a non-integer JS value — hashParquetValue returns undefined
+    const builder = new BloomBuilder({ name: 'i', type: 'INT32' })
+    builder.insert(1)
+    builder.insert(1.5) // unhashable for INT32
+    expect(builder.finalize()).toBeUndefined()
+  })
+
+  it('returns undefined when sizing exceeds maxBytes', () => {
+    const builder = new BloomBuilder(
+      { name: 's', type: 'BYTE_ARRAY' },
+      { fpp: 0.001, maxBytes: 256 }
+    )
+    for (let i = 0; i < 1000; i++) builder.insert(`v-${i}`)
+    expect(builder.finalize()).toBeUndefined()
   })
 })
 

--- a/test/write.bloom.test.js
+++ b/test/write.bloom.test.js
@@ -1,0 +1,150 @@
+import { parquetMetadata } from 'hyparquet'
+import { hashParquetValue, readBloomFilter } from 'hyparquet/src/bloom.js'
+import { describe, expect, it } from 'vitest'
+import { sbbfContains } from '../src/bloom.js'
+import { ByteWriter } from '../src/bytewriter.js'
+import { writeColumn } from '../src/column.js'
+import { parquetWriteBuffer } from '../src/index.js'
+import { snappyCompress } from '../src/snappy.js'
+
+/**
+ * @import {SchemaElement} from 'hyparquet'
+ * @import {ColumnEncoder, PageData} from '../src/types.js'
+ */
+
+/**
+ * @param {SchemaElement} element
+ * @param {Partial<ColumnEncoder>} overrides
+ * @returns {ColumnEncoder}
+ */
+function makeColumn(element, overrides = {}) {
+  return {
+    columnName: element.name,
+    element,
+    schemaPath: [{ name: 'root', num_children: 1 }, element],
+    codec: 'UNCOMPRESSED',
+    compressors: { SNAPPY: snappyCompress },
+    stats: true,
+    pageSize: 0,
+    columnIndex: false,
+    offsetIndex: false,
+    ...overrides,
+  }
+}
+
+/**
+ * @param {any[]} values
+ * @returns {PageData}
+ */
+function makePageData(values) {
+  return {
+    values,
+    definitionLevels: [],
+    repetitionLevels: [],
+    maxDefinitionLevel: 0,
+  }
+}
+
+describe('writeColumn bloom filter', () => {
+  it('does not return a bloom filter when the flag is off', () => {
+    const writer = new ByteWriter()
+    const result = writeColumn({
+      writer,
+      column: makeColumn({ name: 'v', type: 'INT32', repetition_type: 'REQUIRED' }),
+      pageData: makePageData([1, 2, 3]),
+    })
+    expect(result.bloomFilter).toBeUndefined()
+  })
+
+  it('returns a bloom filter containing each inserted value when enabled', () => {
+    const writer = new ByteWriter()
+    const values = ['alpha', 'beta', 'gamma']
+    /** @type {SchemaElement} */
+    const element = { name: 'v', type: 'BYTE_ARRAY', repetition_type: 'REQUIRED' }
+    const result = writeColumn({
+      writer,
+      column: makeColumn(element, { bloomFilter: true }),
+      pageData: makePageData(values),
+    })
+    expect(result.bloomFilter).toBeInstanceOf(Uint32Array)
+    for (const v of values) {
+      const h = hashParquetValue(v, element) ?? 0n
+      expect(sbbfContains(result.bloomFilter ?? new Uint32Array(0), h)).toBe(true)
+    }
+  })
+
+  it('respects fpp option', () => {
+    const writer = new ByteWriter()
+    /** @type {SchemaElement} */
+    const element = { name: 'v', type: 'INT32', repetition_type: 'REQUIRED' }
+    const values = Array.from({ length: 100 }, (_, i) => i)
+    const tight = writeColumn({
+      writer: new ByteWriter(),
+      column: makeColumn(element, { bloomFilter: { fpp: 0.0001 } }),
+      pageData: makePageData(values),
+    }).bloomFilter
+    const loose = writeColumn({
+      writer,
+      column: makeColumn(element, { bloomFilter: { fpp: 0.1 } }),
+      pageData: makePageData(values),
+    }).bloomFilter
+    expect(tight?.byteLength).toBeGreaterThan(loose?.byteLength ?? 0)
+  })
+
+  it('returns undefined when the column type is unhashable (e.g. DATE)', () => {
+    const writer = new ByteWriter()
+    /** @type {SchemaElement} */
+    const element = { name: 'd', type: 'INT32', converted_type: 'DATE', repetition_type: 'REQUIRED' }
+    const result = writeColumn({
+      writer,
+      column: makeColumn(element, { bloomFilter: true }),
+      pageData: makePageData([1, 2, 3]),
+    })
+    expect(result.bloomFilter).toBeUndefined()
+  })
+})
+
+describe('parquetWriteBuffer bloom filter end-to-end', () => {
+  it('writes bloom_filter_offset/length and round-trips via readBloomFilter', () => {
+    const values = Array.from({ length: 500 }, (_, i) => `value-${i}`)
+    const buffer = parquetWriteBuffer({
+      columnData: [
+        { name: 'plain', data: values.slice(), type: 'STRING' },
+        { name: 'bloomed', data: values.slice(), type: 'STRING', bloomFilter: true },
+      ],
+    })
+    const metadata = parquetMetadata(buffer)
+    const [plain, bloomed] = metadata.row_groups[0].columns
+
+    expect(plain.meta_data?.bloom_filter_offset).toBeUndefined()
+    expect(bloomed.meta_data?.bloom_filter_offset).toBeDefined()
+    expect(bloomed.meta_data?.bloom_filter_length).toBeGreaterThan(0)
+
+    const offset = Number(bloomed.meta_data?.bloom_filter_offset)
+    const length = bloomed.meta_data?.bloom_filter_length ?? 0
+    const reader = { view: new DataView(buffer, offset, length), offset: 0 }
+    const parsed = readBloomFilter(reader)
+    expect(parsed).toBeDefined()
+
+    /** @type {SchemaElement} */
+    const element = { name: 'bloomed', type: 'BYTE_ARRAY' }
+    for (const v of values) {
+      const h = hashParquetValue(v, element) ?? 0n
+      expect(sbbfContains(parsed?.blocks ?? new Uint32Array(0), h)).toBe(true)
+    }
+  })
+
+  it('writes one bloom per row group when bloomFilter is enabled', () => {
+    const values = Array.from({ length: 300 }, (_, i) => i)
+    const buffer = parquetWriteBuffer({
+      columnData: [{ name: 'v', data: values, type: 'INT32', bloomFilter: true }],
+      rowGroupSize: 100,
+    })
+    const metadata = parquetMetadata(buffer)
+    expect(metadata.row_groups).toHaveLength(3)
+    for (const rg of metadata.row_groups) {
+      expect(rg.columns[0].meta_data?.bloom_filter_offset).toBeDefined()
+      expect(rg.columns[0].meta_data?.bloom_filter_length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/test/write.bloom.test.js
+++ b/test/write.bloom.test.js
@@ -1,5 +1,7 @@
-import { parquetMetadata } from 'hyparquet'
+import { parquetMetadata, parquetReadObjects } from 'hyparquet'
 import { hashParquetValue, readBloomFilter } from 'hyparquet/src/bloom.js'
+import { parquetSchema } from 'hyparquet/src/metadata.js'
+import { parquetPlan, prefetchBloomFilters } from 'hyparquet/src/plan.js'
 import { describe, expect, it } from 'vitest'
 import { sbbfContains } from '../src/bloom.js'
 import { ByteWriter } from '../src/bytewriter.js'
@@ -146,5 +148,52 @@ describe('parquetWriteBuffer bloom filter end-to-end', () => {
       expect(rg.columns[0].meta_data?.bloom_filter_offset).toBeDefined()
       expect(rg.columns[0].meta_data?.bloom_filter_length).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('bloom pushdown via hyparquet', () => {
+  // RG0 holds {10,90}, RG1 holds {30,70}. Stats ranges [10,90] and [30,70] both
+  // contain 30, so stats alone can't prune. Only the bloom proves 30 absent in RG0.
+  const rg0 = Array.from({ length: 200 }, (_, i) => i % 2 ? 90 : 10)
+  const rg1 = Array.from({ length: 200 }, (_, i) => i % 2 ? 70 : 30)
+  const data = [...rg0, ...rg1]
+
+  function writeFile() {
+    return parquetWriteBuffer({
+      columnData: [{ name: 'code', data, type: 'INT32', bloomFilter: true }],
+      rowGroupSize: 200,
+    })
+  }
+
+  it('parquetPlan prunes a row group that stats cannot', async () => {
+    const file = writeFile()
+    const metadata = parquetMetadata(file)
+    const filter = { code: { $eq: 30 } }
+
+    // Stats-only: both row groups survive.
+    const statsPlan = parquetPlan({ file, metadata, filter })
+    expect(statsPlan.groups.map(g => g.groupStart)).toEqual([0, 200])
+
+    // With bloom: RG0's bloom proves 30 absent → only RG1 remains.
+    const bloomFiltersByGroup = await prefetchBloomFilters({ file, metadata, filter })
+    const schemaTree = parquetSchema(metadata)
+    /** @type {Record<string, SchemaElement>} */
+    const schemaElements = {}
+    for (const child of schemaTree.children) schemaElements[child.element.name] = child.element
+    const bloomPlan = parquetPlan({ file, metadata, filter, bloomFiltersByGroup, schemaElements })
+    expect(bloomPlan.groups.map(g => g.groupStart)).toEqual([200])
+  })
+
+  it('parquetReadObjects with useBloomFilters returns the right rows', async () => {
+    const file = writeFile()
+    const rows = await parquetReadObjects({ file, filter: { code: { $eq: 30 } }, useBloomFilters: true })
+    expect(rows.length).toBe(100) // half of RG1
+    expect(rows.every(r => r.code === 30)).toBe(true)
+  })
+
+  it('bloom proves absence for a value missing from every row group', async () => {
+    const file = writeFile()
+    const rows = await parquetReadObjects({ file, filter: { code: { $eq: 50 } }, useBloomFilters: true })
+    expect(rows).toEqual([])
   })
 })


### PR DESCRIPTION
- Implement bloom filter writing with Split Block Bloom Filter (SBBF) format and xxHash
- Add `BloomBuilder` for accumulating column values and `writeBloomFilter` / `writeBlooms` for serializing filters into the parquet output
- Opt-in per column via bloomFilter: true (or { fpp, maxBytes }) on ColumnSource; disabled by default
