### PR TITLE
Fix min/max statistics truncation for long values

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -117,8 +117,8 @@ export function writeColumn({ writer, column, pageData }) {
 
       columnIndex.null_pages.push(null_count === BigInt(end - start)) // all nulls
       // Spec: for all-null pages set "byte[0]"
-      columnIndex.min_values.push(unconvertMinMax(min_value, element) ?? new Uint8Array())
-      columnIndex.max_values.push(unconvertMinMax(max_value, element) ?? new Uint8Array())
+      columnIndex.min_values.push(unconvertMinMax(min_value, element, false) ?? new Uint8Array())
+      columnIndex.max_values.push(unconvertMinMax(max_value, element, true) ?? new Uint8Array())
       columnIndex.null_counts?.push(null_count)
 
       // Track boundary order using original JS values

--- a/src/unconvert.js
+++ b/src/unconvert.js
@@ -122,17 +122,69 @@ function unconvertUuid(value) {
   throw new Error('UUID must be a string or Uint8Array')
 }
 
+// Statistics min/max values are truncated to this many bytes to bound footer size.
+const STATS_TRUNCATE_LENGTH = 16
+
+/**
+ * Truncate a byte-array statistic to STATS_TRUNCATE_LENGTH bytes.
+ *
+ * A truncated prefix is a valid lower bound (min) but not a valid upper bound:
+ * for a max we must round the prefix up to the smallest byte string that is
+ * still >= the original. We do that by incrementing the last byte that is
+ * < 0xFF, dropping any trailing 0xFF bytes first. If every prefix byte is 0xFF
+ * there is no shorter upper bound, so the max is omitted (returns undefined).
+ *
+ * @param {Uint8Array} bytes
+ * @param {boolean} isMax
+ * @returns {Uint8Array | undefined}
+ */
+function truncateStatistic(bytes, isMax) {
+  if (bytes.length <= STATS_TRUNCATE_LENGTH) return bytes
+  const prefix = bytes.slice(0, STATS_TRUNCATE_LENGTH)
+  if (!isMax) return prefix // a prefix is a valid lower bound
+  let i = prefix.length - 1
+  while (i >= 0 && prefix[i] === 0xff) i-- // drop trailing 0xFF
+  if (i < 0) return undefined // all 0xFF: no valid shorter upper bound
+  const rounded = prefix.slice(0, i + 1)
+  rounded[i] += 1
+  return rounded
+}
+
+/**
+ * Returns false when a min/max value had to be truncated, otherwise undefined.
+ *
+ * We only emit the (optional) exactness flag when it is false; an absent flag
+ * means the value is exact, which keeps the footer small for untruncated columns.
+ *
+ * @param {MinMaxType | undefined} value
+ * @param {SchemaElement} element
+ * @returns {boolean | undefined}
+ */
+function minMaxIsExact(value, element) {
+  if (value === undefined || value === null) return undefined
+  const { type } = element
+  // only byte-array statistics are ever truncated
+  if (type !== 'BYTE_ARRAY' && type !== 'FIXED_LEN_BYTE_ARRAY') return undefined
+  if (element.logical_type?.type === 'UUID') return undefined // exactly 16 bytes, never truncated
+  const bytes = value instanceof Uint8Array ? value : new TextEncoder().encode(value.toString())
+  return bytes.length > STATS_TRUNCATE_LENGTH ? false : undefined
+}
+
 /**
  * Uncovert from rich type to byte array for metadata statistics.
  *
  * @param {MinMaxType | undefined} value
  * @param {SchemaElement} element
+ * @param {boolean} [isMax] whether this is a max value (rounds truncation up)
  * @returns {Uint8Array | undefined}
  */
-export function unconvertMinMax(value, element) {
+export function unconvertMinMax(value, element, isMax = false) {
   if (value === undefined || value === null) return undefined
   const { type, converted_type } = element
   if (type === 'BOOLEAN') return new Uint8Array([value ? 1 : 0])
+  if (element.logical_type?.type === 'UUID' && (typeof value === 'string' || value instanceof Uint8Array)) {
+    return unconvertUuid(value)
+  }
   if (converted_type === 'DECIMAL') {
     if (typeof value !== 'number') throw new Error('DECIMAL must be a number')
     const factor = 10 ** (element.scale || 0)
@@ -150,9 +202,8 @@ export function unconvertMinMax(value, element) {
     }
   }
   if (type === 'BYTE_ARRAY' || type === 'FIXED_LEN_BYTE_ARRAY') {
-    // truncate byte arrays to 16 bytes for statistics
-    if (value instanceof Uint8Array) return value.slice(0, 16)
-    return new TextEncoder().encode(value.toString().slice(0, 16))
+    const bytes = value instanceof Uint8Array ? value : new TextEncoder().encode(value.toString())
+    return truncateStatistic(bytes, isMax)
   }
   if (type === 'FLOAT' && typeof value === 'number') {
     const buffer = new ArrayBuffer(4)
@@ -209,14 +260,14 @@ export function unconvertMinMax(value, element) {
  */
 export function unconvertStatistics(stats, element) {
   return {
-    field_1: unconvertMinMax(stats.max, element),
-    field_2: unconvertMinMax(stats.min, element),
+    field_1: unconvertMinMax(stats.max, element, true),
+    field_2: unconvertMinMax(stats.min, element, false),
     field_3: stats.null_count,
     field_4: stats.distinct_count,
-    field_5: unconvertMinMax(stats.max_value, element),
-    field_6: unconvertMinMax(stats.min_value, element),
-    field_7: stats.is_max_value_exact,
-    field_8: stats.is_min_value_exact,
+    field_5: unconvertMinMax(stats.max_value, element, true),
+    field_6: unconvertMinMax(stats.min_value, element, false),
+    field_7: stats.is_max_value_exact ?? minMaxIsExact(stats.max_value ?? stats.max, element),
+    field_8: stats.is_min_value_exact ?? minMaxIsExact(stats.min_value ?? stats.min, element),
   }
 }
 

--- a/src/unconvert.js
+++ b/src/unconvert.js
@@ -175,10 +175,10 @@ function minMaxIsExact(value, element) {
  *
  * @param {MinMaxType | undefined} value
  * @param {SchemaElement} element
- * @param {boolean} [isMax] whether this is a max value (rounds truncation up)
+ * @param {boolean} isMax whether this is a max value (rounds truncation up)
  * @returns {Uint8Array | undefined}
  */
-export function unconvertMinMax(value, element, isMax = false) {
+export function unconvertMinMax(value, element, isMax) {
   if (value === undefined || value === null) return undefined
   const { type, converted_type } = element
   if (type === 'BOOLEAN') return new Uint8Array([value ? 1 : 0])

--- a/test/unconvert.test.js
+++ b/test/unconvert.test.js
@@ -6,6 +6,22 @@ import { DEFAULT_PARSERS, parseFloat16 } from 'hyparquet/src/convert.js'
 /**
  * @import {SchemaElement, TimeUnit} from 'hyparquet'
  */
+
+/**
+ * Unsigned byte-wise comparison (parquet BYTE_ARRAY sort order).
+ * @param {Uint8Array | undefined} a
+ * @param {Uint8Array} b
+ * @returns {number} negative if a < b, 0 if equal, positive if a > b
+ */
+function compareBytes(a, b) {
+  if (!a) throw new Error('expected a Uint8Array')
+  const len = Math.min(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i]
+  }
+  return a.length - b.length
+}
+
 describe('unconvert', () => {
   it('should return Date objects when converted_type = DATE', () => {
     /** @type {SchemaElement} */
@@ -236,6 +252,60 @@ describe('unconvertMinMax', () => {
     const result2 = unconvertMinMax(longStr, { name: 'test', type: 'FIXED_LEN_BYTE_ARRAY' })
     expect(result2).toBeInstanceOf(Uint8Array)
     expect(result2?.length).toBe(16)
+  })
+
+  it('should truncate a min value to a plain 16-byte prefix', () => {
+    const longStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    // min (isMax = false): a prefix is a valid lower bound, no rounding
+    const min = unconvertMinMax(longStr, { name: 'test', type: 'BYTE_ARRAY' }, false)
+    expect(min).toEqual(new TextEncoder().encode('ABCDEFGHIJKLMNOP'))
+  })
+
+  it('should round a truncated max value up so it stays a valid upper bound', () => {
+    const longStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    const full = new TextEncoder().encode(longStr)
+    // max (isMax = true): prefix with the last byte incremented ('P' -> 'Q')
+    const max = unconvertMinMax(longStr, { name: 'test', type: 'BYTE_ARRAY' }, true)
+    expect(max).toEqual(new TextEncoder().encode('ABCDEFGHIJKLMNOQ'))
+    // invariant: the stored max must be >= the real value, byte-for-byte
+    expect(compareBytes(max, full)).toBeGreaterThanOrEqual(0)
+  })
+
+  it('should drop trailing 0xFF bytes when rounding a max up', () => {
+    // 16-byte prefix ends in 0xFF, 0xFF which cannot be incremented, so they are
+    // dropped and the preceding byte (index 13, 0x4e) is incremented to 0x4f.
+    // Input must exceed 16 bytes so that truncation actually occurs.
+    const prefix = new Uint8Array(16)
+    for (let i = 0; i < 14; i++) prefix[i] = 0x41 + i // 0x41..0x4e
+    prefix[14] = 0xff
+    prefix[15] = 0xff
+    const value = new Uint8Array(20)
+    value.set(prefix)
+    const max = unconvertMinMax(value, { name: 'test', type: 'BYTE_ARRAY' }, true)
+    const expected = prefix.slice(0, 14)
+    expected[13] = 0x4f
+    expect(max).toEqual(expected)
+    expect(compareBytes(max, value)).toBeGreaterThanOrEqual(0)
+  })
+
+  it('should omit a truncated max when every prefix byte is 0xFF', () => {
+    const value = new Uint8Array(20).fill(0xff)
+    const max = unconvertMinMax(value, { name: 'test', type: 'BYTE_ARRAY' }, true)
+    // no shorter byte string is >= all-0xFF, so the max is omitted
+    expect(max).toBeUndefined()
+  })
+
+  it('should encode a UUID as 16 raw bytes, not ASCII text', () => {
+    /** @type {SchemaElement} */
+    const schema = { name: 'test', type: 'FIXED_LEN_BYTE_ARRAY', type_length: 16, logical_type: { type: 'UUID' } }
+    const uuid = '8ad1f570-bb0c-4ad0-9b57-4ad7d2d0f32b'
+    const expected = new Uint8Array([
+      0x8a, 0xd1, 0xf5, 0x70, 0xbb, 0x0c, 0x4a, 0xd0,
+      0x9b, 0x57, 0x4a, 0xd7, 0xd2, 0xd0, 0xf3, 0x2b,
+    ])
+    // exactly 16 bytes -> no truncation, min and max are identical raw bytes
+    expect(unconvertMinMax(uuid, schema, false)).toEqual(expected)
+    expect(unconvertMinMax(uuid, schema, true)).toEqual(expected)
   })
 
   it('should correctly encode FLOAT values in little-endian', () => {

--- a/test/unconvert.test.js
+++ b/test/unconvert.test.js
@@ -228,14 +228,14 @@ describe('unconvertMinMax', () => {
   it('should return undefined if value is undefined or null', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'INT32' }
-    expect(unconvertMinMax(undefined, schema)).toBeUndefined()
+    expect(unconvertMinMax(undefined, schema, false)).toBeUndefined()
   })
 
   it('should handle BOOLEAN type', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'BOOLEAN' }
-    expect(unconvertMinMax(true, schema)).toEqual(new Uint8Array([1]))
-    expect(unconvertMinMax(false, schema)).toEqual(new Uint8Array([0]))
+    expect(unconvertMinMax(true, schema, false)).toEqual(new Uint8Array([1]))
+    expect(unconvertMinMax(false, schema, false)).toEqual(new Uint8Array([0]))
   })
 
   it('should truncate BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY to 16 bytes', () => {
@@ -244,12 +244,12 @@ describe('unconvertMinMax', () => {
     const longStrUint8 = new TextEncoder().encode(longStr)
 
     // value is a Uint8Array
-    const result1 = unconvertMinMax(longStrUint8, { name: 'test', type: 'BYTE_ARRAY' })
+    const result1 = unconvertMinMax(longStrUint8, { name: 'test', type: 'BYTE_ARRAY' }, false)
     expect(result1).toBeInstanceOf(Uint8Array)
     expect(result1?.length).toBe(16)
 
     // value is a string
-    const result2 = unconvertMinMax(longStr, { name: 'test', type: 'FIXED_LEN_BYTE_ARRAY' })
+    const result2 = unconvertMinMax(longStr, { name: 'test', type: 'FIXED_LEN_BYTE_ARRAY' }, false)
     expect(result2).toBeInstanceOf(Uint8Array)
     expect(result2?.length).toBe(16)
   })
@@ -312,7 +312,7 @@ describe('unconvertMinMax', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'FLOAT' }
     const value = 1.5
-    const result = unconvertMinMax(value, schema)
+    const result = unconvertMinMax(value, schema, false)
     expect(result).toBeInstanceOf(Uint8Array)
     const roundtrip = convertMetadata(result, schema, DEFAULT_PARSERS)
     expect(roundtrip).toEqual(1.5)
@@ -322,7 +322,7 @@ describe('unconvertMinMax', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'DOUBLE' }
     const value = 1.123456789
-    const result = unconvertMinMax(value, schema)
+    const result = unconvertMinMax(value, schema, false)
     expect(result).toBeInstanceOf(Uint8Array)
     const roundtrip = convertMetadata(result, schema, DEFAULT_PARSERS)
     expect(roundtrip).toEqual(1.123456789)
@@ -332,7 +332,7 @@ describe('unconvertMinMax', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'INT32' }
     const value = 123456
-    const result = unconvertMinMax(value, schema)
+    const result = unconvertMinMax(value, schema, false)
     const roundtrip = convertMetadata(result, schema, DEFAULT_PARSERS)
     expect(roundtrip).toEqual(123456)
   })
@@ -341,7 +341,7 @@ describe('unconvertMinMax', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'INT64' }
     const value = 1234567890123456789n
-    const result = unconvertMinMax(value, schema)
+    const result = unconvertMinMax(value, schema, false)
     const roundtrip = convertMetadata(result, schema, DEFAULT_PARSERS)
     expect(roundtrip).toEqual(1234567890123456789n)
   })
@@ -350,7 +350,7 @@ describe('unconvertMinMax', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'INT64', converted_type: 'TIMESTAMP_MILLIS' }
     const date = new Date('2023-01-01T00:00:00Z')
-    const result = unconvertMinMax(date, schema)
+    const result = unconvertMinMax(date, schema, false)
     const roundtrip = convertMetadata(result, schema, DEFAULT_PARSERS)
     expect(roundtrip).toEqual(date)
   })
@@ -358,14 +358,14 @@ describe('unconvertMinMax', () => {
   it('should throw an error for unsupported types', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'INT96' }
-    expect(() => unconvertMinMax(123, schema))
+    expect(() => unconvertMinMax(123, schema, false))
       .toThrow('unsupported type for statistics: INT96 with value 123')
   })
 
   it('should throw an error for INT64 if value is a number instead of bigint or Date', () => {
     /** @type {SchemaElement} */
     const schema = { name: 'test', type: 'INT64' }
-    expect(() => unconvertMinMax(123, schema))
+    expect(() => unconvertMinMax(123, schema, false))
       .toThrow('unsupported type for statistics: INT64 with value 123')
   })
 
@@ -427,7 +427,7 @@ describe('unconvertMinMax', () => {
     },
   ]
   it.for(int64EncodeCases)('should encode $name for INT64', ({ schema, value, expected }) => {
-    const result = unconvertMinMax(value, schema)
+    const result = unconvertMinMax(value, schema, false)
     if (!result) throw new Error('expected result')
     const view = new DataView(result.buffer)
     expect(view.getBigInt64(0, true)).toEqual(expected)

--- a/test/write.buffer.test.js
+++ b/test/write.buffer.test.js
@@ -73,14 +73,14 @@ describe('parquetWriteBuffer', () => {
   it('efficiently serializes long string', () => {
     const str = 'a'.repeat(10000)
     const file = parquetWriteBuffer({ columnData: [{ name: 'string', data: [str] }] })
-    expect(file.byteLength).toBe(647)
+    expect(file.byteLength).toBe(649)
   })
 
   it('less efficiently serializes string without compression', () => {
     const str = 'a'.repeat(10000)
     const columnData = [{ name: 'string', data: [str] }]
     const file = parquetWriteBuffer({ columnData, codec: 'UNCOMPRESSED' })
-    expect(file.byteLength).toBe(10176)
+    expect(file.byteLength).toBe(10178)
   })
 
   it('honors per-column codec override', async () => {

--- a/test/write.statistics.test.js
+++ b/test/write.statistics.test.js
@@ -1,0 +1,115 @@
+import { parquetMetadataAsync, parquetQuery, parquetReadObjects } from 'hyparquet'
+import { describe, expect, it } from 'vitest'
+import { parquetWriteBuffer } from '../src/index.js'
+
+/**
+ * @import {BasicType, ColumnSource} from '../src/types.js'
+ * @import {Statistics} from 'hyparquet'
+ */
+
+// A value longer than the 16-byte statistics truncation threshold.
+const LONG = 'this-is-a-very-long-string-value-exceeding-sixteen-bytes' // 56 bytes
+const UUID = '8ad1f570-bb0c-4ad0-9b57-4ad7d2d0f32b' // 36 bytes
+
+/**
+ * @param {any[]} data
+ * @param {BasicType} [type]
+ * @param {Partial<ColumnSource>} [extra]
+ * @returns {ArrayBuffer}
+ */
+function writeCol(data, type = 'STRING', extra = {}) {
+  return parquetWriteBuffer({
+    columnData: [{ name: 'col', data, type, ...extra }],
+    statistics: true,
+  })
+}
+
+/**
+ * @param {ArrayBuffer} buffer
+ * @returns {Promise<Statistics>}
+ */
+async function readStats(buffer) {
+  const meta = await parquetMetadataAsync(buffer)
+  const stats = meta.row_groups[0].columns[0].meta_data?.statistics
+  if (!stats) throw new Error('expected statistics')
+  return stats
+}
+
+describe('statistics truncation of long string values', () => {
+  it('min_value is a valid lower bound and max_value a valid upper bound', async () => {
+    const stats = await readStats(writeCol([LONG]))
+    // The core invariant the reader relies on for predicate pushdown:
+    // every value in the row group must satisfy min <= value <= max.
+    expect(String(stats.min_value) <= LONG).toBe(true)
+    expect(String(stats.max_value) >= LONG).toBe(true)
+  })
+
+  it('finds a single long value with an exact-match query', async () => {
+    const buffer = writeCol([LONG])
+    const rows = await parquetQuery({ file: buffer, filter: { col: { $eq: LONG } } })
+    expect(rows.map(r => r.col)).toEqual([LONG])
+  })
+
+  it('finds a long max value in a multi-value column via $eq', async () => {
+    const buffer = writeCol(['apple', 'banana', LONG])
+    const rows = await parquetQuery({ file: buffer, filter: { col: { $eq: LONG } } })
+    expect(rows.map(r => r.col)).toEqual([LONG])
+  })
+
+  it('finds a long max value via a $gte range query', async () => {
+    const buffer = writeCol(['apple', 'banana', LONG])
+    const rows = await parquetQuery({ file: buffer, filter: { col: { $gte: LONG } } })
+    expect(rows.map(r => r.col)).toEqual([LONG])
+  })
+
+  it('marks truncated bounds as inexact', async () => {
+    const stats = await readStats(writeCol([LONG]))
+    expect(stats.is_min_value_exact).toBe(false)
+    expect(stats.is_max_value_exact).toBe(false)
+  })
+
+  it('leaves short values untruncated and exact', async () => {
+    const stats = await readStats(writeCol(['hello']))
+    expect(stats.min_value).toBe('hello')
+    expect(stats.max_value).toBe('hello')
+    // not flagged inexact (true or omitted are both acceptable, false is not)
+    expect(stats.is_min_value_exact).not.toBe(false)
+    expect(stats.is_max_value_exact).not.toBe(false)
+  })
+
+  it('finds a long value even with page-level column index enabled', async () => {
+    // Multiple pages; the long value lives in a later page so a wrong
+    // page-level max would cause the page to be skipped.
+    const data = Array.from({ length: 50 }, (_, i) => `row-${i}`)
+    data.push(LONG)
+    const buffer = parquetWriteBuffer({
+      columnData: [{ name: 'col', data, type: 'STRING', columnIndex: true }],
+      statistics: true,
+      pageSize: 100, // force multiple pages
+    })
+    const rows = await parquetQuery({ file: buffer, filter: { col: { $eq: LONG } } })
+    expect(rows.map(r => r.col)).toEqual([LONG])
+  })
+})
+
+describe('statistics for UUID columns', () => {
+  it('encodes UUID min/max as the raw 16 bytes, not ASCII text', async () => {
+    // The end-to-end $eq query also requires a hyparquet reader fix (decoding
+    // UUID statistics back to a string); here we assert the writer-side
+    // guarantee that the bytes are the value's true 16-byte big-endian form.
+    const stats = await readStats(writeCol(['00000000-0000-0000-0000-000000000000', UUID], 'UUID'))
+    expect(stats.min_value).toBeInstanceOf(Uint8Array)
+    expect(stats.max_value).toBeInstanceOf(Uint8Array)
+    expect(Array.from(/** @type {Uint8Array} */ (stats.min_value))).toEqual(new Array(16).fill(0))
+    expect(Array.from(/** @type {Uint8Array} */ (stats.max_value))).toEqual([
+      0x8a, 0xd1, 0xf5, 0x70, 0xbb, 0x0c, 0x4a, 0xd0,
+      0x9b, 0x57, 0x4a, 0xd7, 0xd2, 0xd0, 0xf3, 0x2b,
+    ])
+  })
+
+  it('round-trips UUID column data', async () => {
+    const buffer = writeCol([UUID], 'UUID')
+    const rows = await parquetReadObjects({ file: buffer })
+    expect(rows[0].col).toBe(UUID)
+  })
+})


### PR DESCRIPTION
Truncated byte-array statistics used a plain 16-byte prefix for both min and max. A prefix is a valid lower bound but not an upper bound, so the stored max sorted *before* the real value — causing readers to skip row groups on exact and range queries. Any string/UUID longer than 16 bytes (UUIDs, slugs, hashes) returned no rows on `= value` lookups when statistics were enabled.

- max truncation now rounds the prefix up (increment last byte < 0xFF, drop trailing 0xFF, omit if all 0xFF); min unchanged
- UUID logical type now stores the 16 raw bytes instead of ASCII text
- set `is_max/min_value_exact = false` when truncated
- applies to both row-group stats and the page-level column index