### PR TITLE
Support byte arrays in column statistics

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -123,12 +123,14 @@ export function writeColumn({ writer, column, pageData }) {
 
       // Track boundary order using original JS values
       if (prevMinValue !== undefined && min_value !== undefined) {
-        if (prevMinValue > min_value) ascending = false
-        if (prevMinValue < min_value) descending = false
+        const order = compareValues(prevMinValue, min_value)
+        if (order > 0) ascending = false
+        if (order < 0) descending = false
       }
       if (prevMaxValue !== undefined && max_value !== undefined) {
-        if (prevMaxValue > max_value) ascending = false
-        if (prevMaxValue < max_value) descending = false
+        const order = compareValues(prevMaxValue, max_value)
+        if (order > 0) ascending = false
+        if (order < 0) descending = false
       }
       prevMinValue = min_value
       prevMaxValue = max_value
@@ -249,13 +251,34 @@ function getStatistics(values) {
       null_count++
       continue
     }
-    if (typeof value === 'object') continue // skip objects
+    if (typeof value === 'object' && !(value instanceof Uint8Array)) continue
     if (typeof value === 'number' && Number.isNaN(value)) continue // skip NaN per parquet spec
-    if (min_value === undefined || value < min_value) min_value = value
-    if (max_value === undefined || value > max_value) max_value = value
+    if (min_value === undefined || compareValues(value, min_value) < 0) min_value = value
+    if (max_value === undefined || compareValues(value, max_value) > 0) max_value = value
   }
   // Normalize signed zero per parquet spec: min becomes -0, max becomes +0
   if (min_value === 0) min_value = -0
   if (max_value === 0) max_value = 0
   return { min_value, max_value, null_count }
+}
+
+/**
+ * Compare primitive statistic values or Parquet byte arrays. Byte arrays use
+ * unsigned lexicographic order, as required for BYTE_ARRAY min/max bounds.
+ *
+ * @param {any} left
+ * @param {any} right
+ * @returns {number}
+ */
+function compareValues(left, right) {
+  if (left instanceof Uint8Array && right instanceof Uint8Array) {
+    const length = Math.min(left.length, right.length)
+    for (let i = 0; i < length; i += 1) {
+      if (left[i] !== right[i]) return left[i] - right[i]
+    }
+    return left.length - right.length
+  }
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
 }

--- a/test/write.pageindex.test.js
+++ b/test/write.pageindex.test.js
@@ -20,6 +20,39 @@ function indexReader(buffer, offset, length) {
 }
 
 describe('parquetWrite columnIndex and offsetIndex', () => {
+  it('writes byte-array UTF-8 values with the same statistics and pages as strings', () => {
+    const strings = ['alpha', 'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot']
+    const encoder = new TextEncoder()
+    const bytes = strings.map(value => encoder.encode(value))
+    /**
+     * @param {any[]} data
+     * @returns {Omit<import('../src/types.js').ParquetWriteOptions, 'writer'>}
+     */
+    function options(data) {
+      return {
+        columnData: [{
+          name: 'value',
+          data,
+          type: 'STRING',
+          encoding: 'DELTA_BYTE_ARRAY',
+          columnIndex: true,
+        }],
+        pageSize: 12,
+      }
+    }
+    const stringBuffer = parquetWriteBuffer(options(strings))
+    const byteBuffer = parquetWriteBuffer(options(bytes))
+
+    expect(new Uint8Array(byteBuffer)).toEqual(new Uint8Array(stringBuffer))
+    const metadata = parquetMetadata(byteBuffer)
+    const column = metadata.row_groups[0].columns[0]
+    const reader = indexReader(byteBuffer, column.column_index_offset, column.column_index_length)
+    const columnIndex = readColumnIndex(reader, metadata.schema[1])
+    expect(columnIndex.min_values).toEqual(['alpha', 'bravo', 'charlie', 'delta', 'foxtrot'])
+    expect(columnIndex.max_values).toEqual(['alpha', 'bravo', 'charlie', 'echo', 'foxtrot'])
+    expect(columnIndex.boundary_order).toBe('ASCENDING')
+  })
+
   it('writes column index and offset index when both are true', async () => {
     const buffer = parquetWriteBuffer({
       columnData: [


### PR DESCRIPTION
## Summary

- compute row-group and page statistics for `Uint8Array` values using Parquet unsigned lexicographic ordering
- use the same ordering for column-index `boundary_order`
- verify UTF-8 byte-array input produces byte-identical output to string input

This lets callers preserve encoded UTF-8 data through their pipeline without losing page indexes or paying for a decode/re-encode cycle. In HypGrep's WildChat index benchmark, that reduced index creation from 37m49s to 28m29s and peak RSS from 21.14 GB to 17.16 GB.

## Testing

- `npm test` (495 tests)
- `npm run lint`
- `npm run build:types`
- `git diff --check`