### PR TITLE
Write bounding box statistics as explicitly typed doubles

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,11 +1,11 @@
 import { getSchemaPath } from 'hyparquet/src/schema.js'
 import { CompressionCodecs, ConvertedTypes, EdgeInterpolationAlgorithms, Encodings, FieldRepetitionTypes, PageTypes, ParquetTypes } from 'hyparquet/src/constants.js'
-import { serializeTCompactProtocol } from './thrift.js'
+import { DOUBLE, ThriftStruct, serializeTCompactProtocol } from './thrift.js'
 import { unconvertStatistics } from './unconvert.js'
 
 /**
- * @import {FileMetaData, LogicalType, SchemaElement, TimeUnit} from 'hyparquet'
- * @import {ThriftObject, Writer} from '../src/types.js'
+ * @import {BoundingBox, FileMetaData, LogicalType, SchemaElement, TimeUnit} from 'hyparquet'
+ * @import {PreconvertedThriftStruct, ThriftObject, Writer} from '../src/types.js'
  */
 
 /**
@@ -67,16 +67,7 @@ export function writeMetadata(writer, metadata) {
             field_3: c.meta_data.size_statistics.definition_level_histogram,
           },
           field_17: c.meta_data.geospatial_statistics && {
-            field_1: c.meta_data.geospatial_statistics.bbox && {
-              field_1: c.meta_data.geospatial_statistics.bbox.xmin,
-              field_2: c.meta_data.geospatial_statistics.bbox.xmax,
-              field_3: c.meta_data.geospatial_statistics.bbox.ymin,
-              field_4: c.meta_data.geospatial_statistics.bbox.ymax,
-              field_5: c.meta_data.geospatial_statistics.bbox.zmin,
-              field_6: c.meta_data.geospatial_statistics.bbox.zmax,
-              field_7: c.meta_data.geospatial_statistics.bbox.mmin,
-              field_8: c.meta_data.geospatial_statistics.bbox.mmax,
-            },
+            field_1: c.meta_data.geospatial_statistics.bbox && thriftBoundingBox(c.meta_data.geospatial_statistics.bbox),
             field_2: c.meta_data.geospatial_statistics.geospatial_types,
           },
         },
@@ -111,6 +102,25 @@ export function writeMetadata(writer, metadata) {
   // write metadata length
   const metadataLength = writer.offset - metadataStart
   writer.appendUint32(metadataLength)
+}
+
+/**
+ * Convert bounds to a struct with explicitly typed DOUBLE fields.
+ *
+ * @param {BoundingBox} bbox
+ * @returns {PreconvertedThriftStruct}
+ */
+function thriftBoundingBox(bbox) {
+  return new ThriftStruct([
+    [1, DOUBLE, bbox.xmin],
+    [2, DOUBLE, bbox.xmax],
+    [3, DOUBLE, bbox.ymin],
+    [4, DOUBLE, bbox.ymax],
+    [5, DOUBLE, bbox.zmin],
+    [6, DOUBLE, bbox.zmax],
+    [7, DOUBLE, bbox.mmin],
+    [8, DOUBLE, bbox.mmax],
+  ])
 }
 
 /**

--- a/src/thrift.js
+++ b/src/thrift.js
@@ -1,6 +1,5 @@
 /**
- * @import {ThriftType} from 'hyparquet/src/types.js'
- * @import {Writer} from '../src/types.js'
+ * @import {ThriftField, ThriftType, Writer} from '../src/types.js'
  */
 
 // TCompactProtocol types
@@ -10,10 +9,20 @@ const FALSE = 2
 const BYTE = 3
 const I32 = 5
 const I64 = 6
-const DOUBLE = 7
+export const DOUBLE = 7
 const BINARY = 8
 const LIST = 9
 const STRUCT = 12
+
+/** A Thrift struct whose field ids and Compact Protocol types are already resolved. */
+export class ThriftStruct {
+  /**
+   * @param {ThriftField[]} fields
+   */
+  constructor(fields) {
+    this.fields = fields
+  }
+}
 
 /**
  * Serialize a JS object in TCompactProtocol format.
@@ -77,6 +86,14 @@ function writeElement(writer, type, value) {
         writeElement(writer, elemType, v)
       }
     }
+  } else if (type === STRUCT && value instanceof ThriftStruct) {
+    // Field ids and types were explicitly provided by the metadata conversion.
+    let lastFid = 0
+    for (const [fid, fieldType, fieldValue] of value.fields) {
+      if (fieldValue === undefined) continue
+      lastFid = writeStructField(writer, lastFid, fid, fieldType, fieldValue)
+    }
+    writer.appendUint8(STOP)
   } else if (type === STRUCT && typeof value === 'object') {
     // write struct fields
     let lastFid = 0
@@ -88,24 +105,36 @@ function writeElement(writer, type, value) {
         throw new Error(`thrift invalid field name: ${k}. Expected "field_###"`)
       }
       const t = getCompactTypeForValue(v)
-      const delta = fid - lastFid
-      if (delta <= 0) {
-        throw new Error(`thrift non-monotonic field id: fid=${fid}, lastFid=${lastFid}`)
-      }
-      if (delta > 15) {
-        writer.appendUint8(t)
-        writer.appendZigZag(fid)
-      } else {
-        writer.appendUint8(delta << 4 | t)
-      }
-      writeElement(writer, t, v)
-      lastFid = fid
+      lastFid = writeStructField(writer, lastFid, fid, t, v)
     }
     // end struct
     writer.appendUint8(STOP)
   } else {
     throw new Error(`thrift invalid type ${type} for value ${value}`)
   }
+}
+
+/**
+ * @param {Writer} writer
+ * @param {number} lastFid
+ * @param {number} fid
+ * @param {number} type
+ * @param {ThriftType} value
+ * @returns {number}
+ */
+function writeStructField(writer, lastFid, fid, type, value) {
+  const delta = fid - lastFid
+  if (delta <= 0) {
+    throw new Error(`thrift non-monotonic field id: fid=${fid}, lastFid=${lastFid}`)
+  }
+  if (delta > 15) {
+    writer.appendUint8(type)
+    writer.appendZigZag(fid)
+  } else {
+    writer.appendUint8(delta << 4 | type)
+  }
+  writeElement(writer, type, value)
+  return fid
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -115,4 +115,6 @@ export interface Writer {
 }
 
 export type ThriftObject = { [ key: `field_${number}` ]: ThriftType }
-export type ThriftType = boolean | number | bigint | string | Uint8Array | ThriftType[] | ThriftObject | undefined
+export type ThriftField = [fieldId: number, type: number, value: ThriftType]
+export interface PreconvertedThriftStruct { fields: ThriftField[] }
+export type ThriftType = boolean | number | bigint | string | Uint8Array | PreconvertedThriftStruct | ThriftType[] | ThriftObject | undefined

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,5 +1,5 @@
 import { parquetMetadata } from 'hyparquet'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ByteWriter } from '../src/bytewriter.js'
 import { logicalType, writeMetadata } from '../src/metadata.js'
 import { exampleMetadata } from './example.js'
@@ -115,7 +115,7 @@ describe('writeMetadata', () => {
         total_compressed_size: 8n,
       }],
       key_value_metadata: [{ key: 'meta', value: 'data' }],
-      metadata_length: 227,
+      metadata_length: 283,
     }
 
     writeMetadata(writer, extendedMetadata)
@@ -123,6 +123,29 @@ describe('writeMetadata', () => {
 
     const outputMetadata = parquetMetadata(writer.getBuffer())
     expect(outputMetadata).toEqual(extendedMetadata)
+  })
+
+  it('converts bounding boxes to explicitly typed DOUBLE fields', () => {
+    const appendFloat64 = vi.spyOn(ByteWriter.prototype, 'appendFloat64')
+    const metadata = globalThis.structuredClone(exampleMetadata)
+    const element = metadata.schema[1]
+    const columnMetadata = metadata.row_groups[0]?.columns[0]?.meta_data
+    if (!element || !columnMetadata) throw new Error('invalid test metadata')
+
+    element.logical_type = { type: 'GEOMETRY' }
+    columnMetadata.geospatial_statistics = {
+      bbox: { xmin: 1, xmax: 3, ymin: 2, ymax: 4 },
+      geospatial_types: [1],
+    }
+
+    writeMetadata(new ByteWriter(), metadata)
+    expect(appendFloat64.mock.calls).toEqual([[1], [3], [2], [4]])
+
+    appendFloat64.mockClear()
+    element.logical_type = { type: 'GEOGRAPHY' }
+    writeMetadata(new ByteWriter(), metadata)
+    expect(appendFloat64.mock.calls).toEqual([[1], [3], [2], [4]])
+    appendFloat64.mockRestore()
   })
 })
 

--- a/test/thrift.test.js
+++ b/test/thrift.test.js
@@ -2,7 +2,7 @@ import { deserializeTCompactProtocol } from 'hyparquet/src/thrift.js'
 import { describe, expect, it } from 'vitest'
 import { ByteWriter } from '../src/bytewriter.js'
 import { logicalType } from '../src/metadata.js'
-import { serializeTCompactProtocol } from '../src/thrift.js'
+import { DOUBLE, ThriftStruct, serializeTCompactProtocol } from '../src/thrift.js'
 
 const decoder = new TextDecoder()
 
@@ -40,6 +40,16 @@ describe('serializeTCompactProtocol', () => {
     // Decode the binary back into a string
     expect(decoder.decode(result.field_8)).toBe('Hello, Thrift!')
     expect(decoder.decode(result.field_9)).toBe('Hello, Thrift!')
+  })
+
+  it('serializes a pre-converted struct with explicit field types', () => {
+    const writer = new ByteWriter()
+    serializeTCompactProtocol(writer, {
+      field_1: new ThriftStruct([[1, DOUBLE, 1]]),
+    })
+
+    expect(writer.getBytes()[1] & 0x0f).toBe(DOUBLE)
+    expect(deserializeTCompactProtocol({ view: writer.view, offset: 0 }).field_1.field_1).toBe(1)
   })
 
   it('serializes STRUCTs', () => {


### PR DESCRIPTION
Geospatial bounding box values with whole-number coordinates were being serialized as thrift integers, because the compact protocol type was inferred from the JavaScript value. Readers that expect the spec's double fields would fail to parse the metadata. This adds a ThriftStruct wrapper that lets the metadata writer pin explicit field types, and uses it to always write bbox fields as doubles for both GEOMETRY and GEOGRAPHY columns.

Fixes #33