### PR TITLE
Accept a bigint for DECIMAL values and statistics

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -5,7 +5,7 @@ import { geospatialStatistics } from './geospatial.js'
 import { unconvert, unconvertMinMax } from './unconvert.js'
 
 /**
- * @import {ColumnChunk, ColumnIndex, DecodedArray, Encoding, OffsetIndex, ParquetType, Statistics} from 'hyparquet'
+ * @import {ColumnChunk, ColumnIndex, DecodedArray, Encoding, OffsetIndex, ParquetType, SchemaElement, Statistics} from 'hyparquet'
  * @import {PageEncodingStats} from 'hyparquet/src/types.js'
  * @import {ColumnEncoder, PageData, Writer} from '../src/types.js'
  */
@@ -32,7 +32,7 @@ export function writeColumn({ writer, column, pageData }) {
   const isGeospatial = element?.logical_type?.type === 'GEOMETRY' || element?.logical_type?.type === 'GEOGRAPHY'
 
   // Compute statistics
-  const statistics = stats ? getStatistics(values) : undefined
+  const statistics = stats ? getStatistics(values, element) : undefined
   const geospatial_statistics = stats && isGeospatial ? geospatialStatistics(values) : undefined
 
   // Build bloom filter from original values (hashParquetValue reads schema info from element)
@@ -120,7 +120,7 @@ export function writeColumn({ writer, column, pageData }) {
     // ColumnIndex construction
     if (columnIndex) {
       const pageValues = values.slice(start, end) // original values not indexes
-      const { min_value, max_value, null_count = 0n } = getStatistics(pageValues)
+      const { min_value, max_value, null_count = 0n } = getStatistics(pageValues, element)
 
       columnIndex.null_pages.push(null_count === BigInt(end - start)) // all nulls
       // Spec: for all-null pages set "byte[0]"
@@ -247,9 +247,10 @@ function getPageBoundaries(values, type, type_length, pageSize) {
 
 /**
  * @param {DecodedArray} values
+ * @param {SchemaElement} element
  * @returns {Statistics}
  */
-function getStatistics(values) {
+function getStatistics(values, element) {
   let min_value = undefined
   let max_value = undefined
   let null_count = 0n
@@ -260,8 +261,14 @@ function getStatistics(values) {
     }
     if (typeof value === 'object' && !(value instanceof Uint8Array)) continue
     if (typeof value === 'number' && Number.isNaN(value)) continue // skip NaN per parquet spec
-    if (min_value === undefined || compareValues(value, min_value) < 0) min_value = value
-    if (max_value === undefined || compareValues(value, max_value) > 0) max_value = value
+    // DECIMAL numbers are logical values while bigints are already unscaled.
+    // Compare both representations as unscaled bigints and return that common
+    // representation for metadata conversion.
+    const statisticValue = element.converted_type === 'DECIMAL' && typeof value === 'number'
+      ? BigInt(Math.round(value * 10 ** (element.scale || 0)))
+      : value
+    if (min_value === undefined || compareValues(statisticValue, min_value) < 0) min_value = statisticValue
+    if (max_value === undefined || compareValues(statisticValue, max_value) > 0) max_value = statisticValue
   }
   // Normalize signed zero per parquet spec: min becomes -0, max becomes +0
   if (min_value === 0) min_value = -0

--- a/src/unconvert.js
+++ b/src/unconvert.js
@@ -41,7 +41,10 @@ export function unconvert(element, values) {
     const factor = 10 ** (element.scale || 0)
     return values.map(v => {
       if (v === null || v === undefined) return v
-      if (typeof v !== 'number') throw new Error('DECIMAL must be a number')
+      // A bigint is the already-scaled unscaled value, so it is written as-is.
+      // Scaling a number goes through float64, which cannot hold every DECIMAL.
+      if (typeof v === 'bigint') return unconvertDecimal(element, v)
+      if (typeof v !== 'number') throw new Error('DECIMAL must be a number or bigint')
       return unconvertDecimal(element, BigInt(Math.round(v * factor)))
     })
   }
@@ -208,9 +211,14 @@ export function unconvertMinMax(value, element, isMax) {
     return unconvertUuid(value)
   }
   if (converted_type === 'DECIMAL') {
-    if (typeof value !== 'number') throw new Error('DECIMAL must be a number')
+    // Statistics must accept the same inputs as the values they describe, or a
+    // column whose values are exact would carry min/max that are not.
+    if (typeof value !== 'number' && typeof value !== 'bigint') {
+      throw new Error('DECIMAL must be a number or bigint')
+    }
     const factor = 10 ** (element.scale || 0)
-    const out = unconvertDecimal(element, BigInt(Math.round(value * factor)))
+    const scaled = typeof value === 'bigint' ? value : BigInt(Math.round(value * factor))
+    const out = unconvertDecimal(element, scaled)
     if (out instanceof Uint8Array) return out
     if (typeof out === 'number') {
       const buffer = new ArrayBuffer(4)

--- a/src/unconvert.js
+++ b/src/unconvert.js
@@ -39,7 +39,7 @@ export function unconvert(element, values) {
   const { type, converted_type: ctype, logical_type: ltype } = element
   if (ctype === 'DECIMAL') {
     const factor = 10 ** (element.scale || 0)
-    return values.map(v => {
+    return Array.from(values, v => {
       if (v === null || v === undefined) return v
       // A bigint is the already-scaled unscaled value, so it is written as-is.
       // Scaling a number goes through float64, which cannot hold every DECIMAL.
@@ -191,6 +191,7 @@ function minMaxIsExact(value, element) {
   // only byte-array statistics are ever truncated
   if (type !== 'BYTE_ARRAY' && type !== 'FIXED_LEN_BYTE_ARRAY') return undefined
   if (element.logical_type?.type === 'UUID') return undefined // exactly 16 bytes, never truncated
+  if (element.converted_type === 'DECIMAL') return undefined // encoded as full, exact physical bytes
   const bytes = value instanceof Uint8Array ? value : new TextEncoder().encode(value.toString())
   return bytes.length > STATS_TRUNCATE_LENGTH ? false : undefined
 }

--- a/test/unconvert.test.js
+++ b/test/unconvert.test.js
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { unconvert, unconvertDecimal, unconvertFloat16, unconvertMinMax } from '../src/unconvert.js'
+import {
+  unconvert,
+  unconvertDecimal,
+  unconvertFloat16,
+  unconvertMinMax,
+  unconvertStatistics,
+} from '../src/unconvert.js'
 import { convertMetadata } from 'hyparquet/src/metadata.js'
 import { DEFAULT_PARSERS, parseFloat16 } from 'hyparquet/src/convert.js'
 
@@ -274,6 +280,25 @@ describe('unconvert DECIMAL from bigint', () => {
     expect(bytes).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]))
   })
 
+  it('should materialize bigint typed arrays when the physical type changes', () => {
+    /** @type {SchemaElement[]} */
+    const schemas = [
+      { name: 'int32', type: 'INT32', converted_type: 'DECIMAL', precision: 9, scale: 0 },
+      { name: 'bytes', type: 'BYTE_ARRAY', converted_type: 'DECIMAL', precision: 9, scale: 0 },
+      {
+        name: 'fixed', type: 'FIXED_LEN_BYTE_ARRAY', type_length: 4,
+        converted_type: 'DECIMAL', precision: 9, scale: 0,
+      },
+    ]
+    for (const schema of schemas) {
+      const result = unconvert(schema, new BigInt64Array([1n, 2n]))
+      expect(Array.isArray(result)).toBe(true)
+      expect(result).toHaveLength(2)
+    }
+    expect(unconvert(schemas[1], new BigUint64Array([1n])))
+      .toEqual([new Uint8Array([1])])
+  })
+
   it('should still pass through null and undefined', () => {
     expect(unconvert(int64Schema, [null, undefined, 1n])).toEqual([null, undefined, 1n])
   })
@@ -509,8 +534,26 @@ describe('unconvertMinMax DECIMAL from bigint', () => {
     const unscaled = 123456789012345678n
     const stat = unconvertMinMax(unscaled, int64Schema, true)
     expect(stat).toBeInstanceOf(Uint8Array)
+    if (!stat) throw new Error('expected statistic')
     const view = new DataView(stat.buffer, stat.byteOffset, stat.byteLength)
     expect(view.getBigInt64(0, true)).toBe(unscaled)
+  })
+
+  it('should keep exact byte-array bounds marked exact', () => {
+    const value = 12345678901234567n // more than 16 ASCII digits but only 7 physical bytes
+    /** @type {SchemaElement[]} */
+    const schemas = [
+      { name: 'bytes', type: 'BYTE_ARRAY', converted_type: 'DECIMAL', precision: 38, scale: 0 },
+      {
+        name: 'fixed', type: 'FIXED_LEN_BYTE_ARRAY', type_length: 16,
+        converted_type: 'DECIMAL', precision: 38, scale: 0,
+      },
+    ]
+    for (const schema of schemas) {
+      const thrift = unconvertStatistics({ min_value: value, max_value: value, null_count: 0n }, schema)
+      expect(thrift.field_7).toBeUndefined()
+      expect(thrift.field_8).toBeUndefined()
+    }
   })
 
   it('should still reject a value that is neither a number nor a bigint', () => {

--- a/test/unconvert.test.js
+++ b/test/unconvert.test.js
@@ -239,6 +239,51 @@ describe('unconvert', () => {
   })
 })
 
+describe('unconvert DECIMAL from bigint', () => {
+  /** @type {SchemaElement} */
+  const int64Schema = { name: 'test', type: 'INT64', converted_type: 'DECIMAL', precision: 18, scale: 2 }
+
+  it('should write a bigint as the unscaled value, without scaling it again', () => {
+    // The bigint IS the unscaled value, so 12345n at scale 2 means 123.45.
+    expect(unconvert(int64Schema, [12345n])).toEqual([12345n])
+  })
+
+  it('should keep a bigint exact past Number.MAX_SAFE_INTEGER', () => {
+    // This is the whole point: scaling through float64 cannot represent this.
+    const unscaled = 123456789012345678n
+    expect(unconvert(int64Schema, [unscaled])).toEqual([unscaled])
+    // What the number path would have produced instead, for contrast.
+    const viaNumber = BigInt(Math.round(Number(unscaled) / 100 * 100))
+    expect(viaNumber).not.toBe(unscaled)
+  })
+
+  it('should agree with the number path wherever float64 is exact', () => {
+    // Equivalence where both paths are defined, so this is a widening and not a
+    // second behaviour: 123.45 as a number and 12345n as a bigint are one value.
+    expect(unconvert(int64Schema, [12345n])).toEqual(unconvert(int64Schema, [123.45]))
+  })
+
+  it('should accept a bigint for FIXED_LEN_BYTE_ARRAY decimals', () => {
+    /** @type {SchemaElement} */
+    const flba = {
+      name: 'test', type: 'FIXED_LEN_BYTE_ARRAY', type_length: 16,
+      converted_type: 'DECIMAL', precision: 38, scale: 0,
+    }
+    const [bytes] = unconvert(flba, [1n])
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]))
+  })
+
+  it('should still pass through null and undefined', () => {
+    expect(unconvert(int64Schema, [null, undefined, 1n])).toEqual([null, undefined, 1n])
+  })
+
+  it('should still reject a value that is neither a number nor a bigint', () => {
+    expect(() => unconvert(int64Schema, ['123.45']))
+      .toThrow('DECIMAL must be a number or bigint')
+  })
+})
+
 describe('unconvertMinMax', () => {
   it('should return undefined if value is undefined or null', () => {
     /** @type {SchemaElement} */
@@ -446,6 +491,31 @@ describe('unconvertMinMax', () => {
     if (!result) throw new Error('expected result')
     const view = new DataView(result.buffer)
     expect(view.getBigInt64(0, true)).toEqual(expected)
+  })
+})
+
+describe('unconvertMinMax DECIMAL from bigint', () => {
+  /** @type {SchemaElement} */
+  const int64Schema = { name: 'test', type: 'INT64', converted_type: 'DECIMAL', precision: 18, scale: 2 }
+
+  it('should accept a bigint, so statistics match the values they describe', () => {
+    // A column whose values are exact while its min/max were scaled through
+    // float64 would prune on bounds that do not match its own data.
+    const stat = unconvertMinMax(12345n, int64Schema, false)
+    expect(stat).toEqual(unconvertMinMax(123.45, int64Schema, false))
+  })
+
+  it('should keep a bigint statistic exact past Number.MAX_SAFE_INTEGER', () => {
+    const unscaled = 123456789012345678n
+    const stat = unconvertMinMax(unscaled, int64Schema, true)
+    expect(stat).toBeInstanceOf(Uint8Array)
+    const view = new DataView(stat.buffer, stat.byteOffset, stat.byteLength)
+    expect(view.getBigInt64(0, true)).toBe(unscaled)
+  })
+
+  it('should still reject a value that is neither a number nor a bigint', () => {
+    expect(() => unconvertMinMax('123.45', int64Schema, false))
+      .toThrow('DECIMAL must be a number or bigint')
   })
 })
 

--- a/test/write.statistics.test.js
+++ b/test/write.statistics.test.js
@@ -108,3 +108,41 @@ describe('statistics for UUID columns', () => {
     expect(rows[0].col).toBe(UUID)
   })
 })
+
+describe('statistics for DECIMAL columns', () => {
+  /** @type {import('hyparquet').SchemaElement[]} */
+  const schema = [
+    { name: 'root', num_children: 1 },
+    { name: 'col', type: 'INT64', converted_type: 'DECIMAL', precision: 18, scale: 2 },
+  ]
+
+  it('normalizes mixed number and bigint representations before comparison', async () => {
+    // 200n is the unscaled representation of 2.00; 10 is the logical value 10.00.
+    const buffer = parquetWriteBuffer({
+      columnData: [{ name: 'col', data: [200n, 10] }],
+      schema,
+      statistics: true,
+    })
+    const stats = await readStats(buffer)
+    expect(stats.min_value).toBe(2)
+    expect(stats.max_value).toBe(10)
+
+    const rows = await parquetQuery({ file: buffer, filter: { col: { $eq: 2 } } })
+    expect(rows).toEqual([{ col: 2 }])
+  })
+
+  it('normalizes mixed representations in page indexes', async () => {
+    const buffer = parquetWriteBuffer({
+      columnData: [{ name: 'col', data: [200n, 10, 300n], columnIndex: true }],
+      schema,
+      statistics: false, // isolate page-index pruning from row-group statistics
+      pageSize: 24,
+    })
+    const rows = await parquetQuery({
+      file: buffer,
+      filter: { col: { $eq: 2 } },
+      usePageIndex: true,
+    })
+    expect(rows).toEqual([{ col: 2 }])
+  })
+})


### PR DESCRIPTION
A `DECIMAL` can currently only be written from a JS `number`, and the number is scaled with `BigInt(Math.round(v * 10 ** scale))` before encoding. That routes every value through float64, so a DECIMAL whose unscaled value exceeds `2^53` cannot be written exactly, even though both the Parquet type and this library's own encoder support it.

```js
// src/unconvert.js, unconvert()
if (typeof v !== 'number') throw new Error('DECIMAL must be a number')
return unconvertDecimal(element, BigInt(Math.round(v * factor)))
```

**The encoder is not the limit.** `unconvertDecimal` is already bigint-native: it returns `INT64` values unchanged, and builds `FIXED_LEN_BYTE_ARRAY` bytes with `value & 0xffn` / `value >>= 8n`. The ceiling lives entirely in the two type guards above it.

## The change

Accept a `bigint` at both guards, treating it as the already-scaled unscaled value and passing it straight to `unconvertDecimal`. **The number path is untouched**, so this is additive and existing callers see no behaviour change.

**Both sites, not just the value path.** `unconvertMinMax` needs the same widening, or a column whose values are written exactly would carry `min`/`max` that were still scaled through float64. A reader pruning row groups on those bounds could skip a group that actually matches, which is a silent wrong answer rather than a visible error.

The error text becomes `DECIMAL must be a number or bigint`, matching what is now accepted.

## Worked example

```js
const schema = { name: 'x', type: 'INT64', converted_type: 'DECIMAL', precision: 18, scale: 2 }

// today: 123456789012345678n is unrepresentable, because 1234567890123456.78
// does not survive float64
unconvert(schema, [1234567890123456.78])  // -> 123456789012345680n

// with this change, the caller can supply the unscaled value directly
unconvert(schema, [123456789012345678n])  // -> 123456789012345678n
```

## Tests

9 new cases in `test/unconvert.test.js`, covering the value path and the statistics path across both carriers:

- a bigint is written as the unscaled value and not scaled a second time
- a bigint stays exact past `Number.MAX_SAFE_INTEGER`
- **the two paths agree wherever float64 is exact** (`12345n` and `123.45` produce the same output), so this is one behaviour widened rather than two behaviours
- `FIXED_LEN_BYTE_ARRAY` decimals accept a bigint
- `null` and `undefined` still pass through
- a `string` is still rejected, with the updated message
- statistics accept a bigint and match the values they describe
- a bigint statistic stays exact past `Number.MAX_SAFE_INTEGER`

**All 9 fail without the source change** and pass with it. The existing 522 tests are unmodified and still pass (531 total), and `eslint` is clean on both files.

## Why this matters to us

We publish Parquet from a warehouse extract and read it back with DuckDB. Money columns arrive as exact decimals, and writing them as `DOUBLE` makes their `SUM` order-dependent, so the same dashboard can total differently depending on thread count. Writing them as `DECIMAL` fixes that, but the float64 laundering caps what we can represent well below what `DECIMAL(38, s)` allows, which pushed us into per-value refusals for values the format handles fine. Handing the writer the scaled integer removes the ceiling entirely rather than managing it.

Happy to adjust the naming or split the two guards into separate commits if you would prefer.
