### PR TITLE
Fix INT32 DECIMAL statistics encoding

### DIFF
--- a/src/unconvert.js
+++ b/src/unconvert.js
@@ -223,7 +223,7 @@ export function unconvertMinMax(value, element, isMax) {
     if (out instanceof Uint8Array) return out
     if (typeof out === 'number') {
       const buffer = new ArrayBuffer(4)
-      new DataView(buffer).setFloat32(0, out, true)
+      new DataView(buffer).setInt32(0, out, true)
       return new Uint8Array(buffer)
     }
     if (typeof out === 'bigint') {

--- a/test/write.statistics.test.js
+++ b/test/write.statistics.test.js
@@ -145,4 +145,18 @@ describe('statistics for DECIMAL columns', () => {
     })
     expect(rows).toEqual([{ col: 2 }])
   })
+
+  it('writes INT32 decimal statistics as int32, not float32', async () => {
+    const buffer = parquetWriteBuffer({
+      columnData: [{ name: 'price', data: [123.45, -0.5] }],
+      schema: [
+        { name: 'root', num_children: 1 },
+        { name: 'price', type: 'INT32', repetition_type: 'OPTIONAL', converted_type: 'DECIMAL', precision: 6, scale: 2 },
+      ],
+      statistics: true,
+    })
+    const stats = await readStats(buffer)
+    expect(stats.min_value).toBe(-0.5)
+    expect(stats.max_value).toBe(123.45)
+  })
 })


### PR DESCRIPTION
Min and max statistics for INT32 decimal columns were serialized as float32 bytes instead of int32, so a column containing 123.45 reported bounds of about 11.8 million. Readers that prune on statistics, like DuckDB, would skip matching row groups. This also affected page index bounds since they share the same code path. INT64 and byte-array decimals were unaffected. Adds a regression test.

Fixes #38